### PR TITLE
MR-review tab + n8n approve webhook (#11)

### DIFF
--- a/dashboard/electron/main/index.js
+++ b/dashboard/electron/main/index.js
@@ -1,7 +1,31 @@
-import { app, BrowserWindow, ipcMain } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog } from 'electron'
 import { join } from 'path'
 import { existsSync } from 'fs'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { listSubsystems, readHistory, buildIndex } from './metrics.js'
+import { listPipelinePrs, approveMr } from './mr_review.js'
+
+const execFileAsync = promisify(execFile)
+
+// Overridable via env for pointing at a real n8n webhook once G-Eskayo/marvin#11's
+// "exact n8n node topology" downstream work exists; defaults to the reference
+// receiver in dashboard/webhook-server/ (see its README for the contract).
+const MR_WEBHOOK_URL = process.env.MARVIN_MR_WEBHOOK_URL || 'http://localhost:7878/approve'
+
+async function listOpenPrs() {
+  const { stdout } = await execFileAsync('gh', [
+    'pr',
+    'list',
+    '--repo',
+    'G-Eskayo/marvin',
+    '--state',
+    'open',
+    '--json',
+    'number,title,url,body'
+  ])
+  return JSON.parse(stdout)
+}
 
 process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true'
 
@@ -49,8 +73,39 @@ function registerMetricsHandlers() {
   ipcMain.handle('metrics:history', (_event, subsystem) => readHistory(subsystem))
 }
 
+function registerMrReviewHandlers() {
+  ipcMain.handle('mr:list', () => listPipelinePrs(listOpenPrs))
+
+  // The actual "unambiguous, no risk of accidental merge from a stray click"
+  // requirement (G-Eskayo/marvin#11's acceptance criteria) lives here, not in
+  // the renderer -- a native OS-level confirm dialog can't be spoofed by a
+  // fast double-click the way a custom in-page confirm affordance could.
+  ipcMain.handle('mr:approve', async (_event, { number, url }) => {
+    const { response } = await dialog.showMessageBox(mainWindow, {
+      type: 'warning',
+      buttons: ['Cancel', 'Merge PR'],
+      defaultId: 0,
+      cancelId: 0,
+      message: `Merge PR #${number}?`,
+      detail: `This fires the approval webhook and merges ${url} via gh pr merge. This can't be undone from here.`
+    })
+    if (response !== 1) {
+      return { merged: false, cancelled: true }
+    }
+    await approveMr(url, MR_WEBHOOK_URL, (webhookUrl, body) =>
+      fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+    )
+    return { merged: true, cancelled: false }
+  })
+}
+
 app.whenReady().then(() => {
   registerMetricsHandlers()
+  registerMrReviewHandlers()
   createWindow()
 
   app.on('activate', () => {

--- a/dashboard/electron/main/mr_review.js
+++ b/dashboard/electron/main/mr_review.js
@@ -1,0 +1,63 @@
+// Reads open PRs and identifies which were raised by the MR pipeline
+// (mr_raiser.py, G-Eskayo/marvin#4) rather than a live/manual session, by
+// matching the exact marker string _default_open_pr() always writes into
+// the body. Parses the attached metrics-comparison table back out for
+// display. Approving fires a webhook per the documented contract (see
+// dashboard/webhook-server/README.md) rather than running `gh pr merge`
+// itself -- G-Eskayo/marvin#11 is explicit that the dashboard is a
+// trigger, not the thing that does the merge.
+const PIPELINE_MARKER = 'Autonomously implemented and verified by the MR pipeline'
+
+export function isPipelinePr(body) {
+  return typeof body === 'string' && body.includes(PIPELINE_MARKER)
+}
+
+export function parseMetricsEvidence(body) {
+  const subsystemMatch = body.match(/\*\*Subsystem\*\*:\s*(.+)/)
+  const verdictMatch = body.match(/\*\*Verdict\*\*:\s*(.+)/)
+
+  const lines = body.split('\n')
+  const headerIndex = lines.findIndex((line) => /^\|\s*Metric\s*\|/.test(line.trim()))
+  const rows = []
+  if (headerIndex !== -1) {
+    // headerIndex + 1 is the "|---|---|..." separator row -- skip it too.
+    for (let i = headerIndex + 2; i < lines.length; i++) {
+      const line = lines[i].trim()
+      if (!line.startsWith('|')) break
+      const cells = line
+        .split('|')
+        .slice(1, -1)
+        .map((c) => c.trim())
+      if (cells.length === 5) {
+        const [name, baseline, current, delta, direction] = cells
+        rows.push({ name, baseline, current, delta, direction })
+      }
+    }
+  }
+
+  return {
+    subsystem: subsystemMatch ? subsystemMatch[1].trim() : null,
+    verdict: verdictMatch ? verdictMatch[1].trim() : null,
+    metrics: rows
+  }
+}
+
+export async function listPipelinePrs(listOpenPrs) {
+  const prs = await listOpenPrs()
+  return prs
+    .filter((pr) => isPipelinePr(pr.body))
+    .map((pr) => ({
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      evidence: parseMetricsEvidence(pr.body)
+    }))
+}
+
+export async function approveMr(prUrl, webhookUrl, post) {
+  const response = await post(webhookUrl, { pr_url: prUrl })
+  if (!response.ok) {
+    throw new Error(`Webhook call failed: ${response.status}`)
+  }
+  return response
+}

--- a/dashboard/electron/preload/index.js
+++ b/dashboard/electron/preload/index.js
@@ -8,5 +8,11 @@ contextBridge.exposeInMainWorld('api', {
     index: () => ipcRenderer.invoke('metrics:index'),
     subsystems: () => ipcRenderer.invoke('metrics:subsystems'),
     history: (subsystem) => ipcRenderer.invoke('metrics:history', subsystem)
+  },
+  mr: {
+    list: () => ipcRenderer.invoke('mr:list'),
+    // Confirmation happens in the main process via a native dialog, not here --
+    // see the comment on the mr:approve handler for why.
+    approve: (pr) => ipcRenderer.invoke('mr:approve', pr)
   }
 })

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,21 +1,11 @@
 import { useState } from 'react'
 import MetricsScorecard from '@components/MetricsScorecard.jsx'
+import MrReview from '@components/MrReview.jsx'
 
-// Two tabs, per G-Eskayo/marvin#10's acceptance criteria: this shell plus
-// the metrics tab now, with room for the MR-review tab (G-Eskayo/marvin#11)
-// to be added later without restructuring this file.
 const TABS = [
   { id: 'metrics', label: 'Metrics' },
   { id: 'mr-review', label: 'MR Review' }
 ]
-
-function MrReviewPlaceholder() {
-  return (
-    <div className="flex h-full items-center justify-center text-neutral-500">
-      <p>MR review lands in G-Eskayo/marvin#11.</p>
-    </div>
-  )
-}
 
 export default function App() {
   const [activeTab, setActiveTab] = useState('metrics')
@@ -41,7 +31,7 @@ export default function App() {
         </nav>
       </header>
       <main className="flex-1 overflow-auto">
-        {activeTab === 'metrics' ? <MetricsScorecard /> : <MrReviewPlaceholder />}
+        {activeTab === 'metrics' ? <MetricsScorecard /> : <MrReview />}
       </main>
     </div>
   )

--- a/dashboard/src/components/MrReview.jsx
+++ b/dashboard/src/components/MrReview.jsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react'
+
+function EmptyState() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-neutral-500">
+      <p className="text-lg font-medium text-neutral-300">No MRs waiting on you</p>
+      <p className="max-w-md text-sm">
+        This fills in once the pipeline's sandbox orchestration raises a PR with metrics evidence attached.
+        Manually-opened PRs (like this dashboard's own) don't show up here on purpose.
+      </p>
+    </div>
+  )
+}
+
+function VerdictBadge({ verdict }) {
+  if (!verdict) return null
+  const good = verdict.toLowerCase().includes('improve')
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+        good ? 'bg-green-950 text-green-400' : 'bg-amber-950 text-amber-400'
+      }`}
+    >
+      {verdict}
+    </span>
+  )
+}
+
+function EvidenceTable({ metrics }) {
+  if (metrics.length === 0) {
+    return <p className="text-sm text-neutral-500">No metrics table attached.</p>
+  }
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left text-neutral-500">
+          <th className="pb-1 pr-4 font-normal">Metric</th>
+          <th className="pb-1 pr-4 font-normal">Baseline</th>
+          <th className="pb-1 pr-4 font-normal">Current</th>
+          <th className="pb-1 font-normal">Delta</th>
+        </tr>
+      </thead>
+      <tbody className="font-mono text-neutral-200">
+        {metrics.map((m) => (
+          <tr key={m.name}>
+            <td className="pr-4 py-0.5">{m.name}</td>
+            <td className="pr-4 py-0.5 text-neutral-400">{m.baseline}</td>
+            <td className="pr-4 py-0.5">{m.current}</td>
+            <td className={`py-0.5 ${m.direction === 'up' ? 'text-green-400' : 'text-amber-400'}`}>{m.delta}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function PrCard({ pr, onApproved }) {
+  const [status, setStatus] = useState('idle') // idle | approving | error
+  const [errorMessage, setErrorMessage] = useState(null)
+
+  async function handleApprove() {
+    setStatus('approving')
+    setErrorMessage(null)
+    try {
+      const result = await window.api.mr.approve({ number: pr.number, url: pr.url })
+      if (result.cancelled) {
+        setStatus('idle')
+        return
+      }
+      onApproved(pr.number)
+    } catch (err) {
+      setStatus('error')
+      setErrorMessage(String(err))
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="font-mono text-sm font-semibold text-white">
+            #{pr.number} — {pr.title}
+          </h3>
+          {pr.evidence.subsystem && (
+            <p className="text-xs text-neutral-500">
+              {pr.evidence.subsystem} <VerdictBadge verdict={pr.evidence.verdict} />
+            </p>
+          )}
+        </div>
+        <button
+          onClick={handleApprove}
+          disabled={status === 'approving'}
+          className="shrink-0 rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-500 disabled:opacity-50"
+        >
+          {status === 'approving' ? 'Confirming…' : 'Approve & Merge'}
+        </button>
+      </div>
+      <EvidenceTable metrics={pr.evidence.metrics} />
+      {status === 'error' && <p className="mt-2 text-sm text-red-400">Failed: {errorMessage}</p>}
+    </div>
+  )
+}
+
+export default function MrReview() {
+  const [prs, setPrs] = useState(null)
+  const [error, setError] = useState(null)
+
+  function reload() {
+    window.api.mr
+      .list()
+      .then(setPrs)
+      .catch((err) => setError(String(err)))
+  }
+
+  useEffect(reload, [])
+
+  if (error) {
+    return <div className="flex h-full items-center justify-center text-red-400">Failed to load MRs: {error}</div>
+  }
+  if (prs === null) {
+    return <div className="flex h-full items-center justify-center text-neutral-500">Loading…</div>
+  }
+  if (prs.length === 0) {
+    return <EmptyState />
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <p className="text-sm text-neutral-500">
+        {prs.length} pipeline-raised PR{prs.length === 1 ? '' : 's'} awaiting review.
+      </p>
+      {prs.map((pr) => (
+        <PrCard key={pr.number} pr={pr} onApproved={reload} />
+      ))}
+    </div>
+  )
+}

--- a/dashboard/test/merge.test.js
+++ b/dashboard/test/merge.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mergePr } from '../webhook-server/merge.js'
+
+describe('mergePr', () => {
+  it('rejects a non-GitHub URL without calling exec', async () => {
+    const exec = vi.fn()
+    await expect(mergePr('not-a-url', exec)).rejects.toThrow('Not a GitHub PR URL')
+    expect(exec).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-string input without throwing a different error', async () => {
+    const exec = vi.fn()
+    await expect(mergePr(undefined, exec)).rejects.toThrow('Not a GitHub PR URL')
+    expect(exec).not.toHaveBeenCalled()
+  })
+
+  it('calls gh pr merge with the exact URL for a valid GitHub PR link', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+    await mergePr('https://github.com/G-Eskayo/marvin/pull/71', exec)
+    expect(exec).toHaveBeenCalledWith('gh', ['pr', 'merge', 'https://github.com/G-Eskayo/marvin/pull/71', '--merge'])
+  })
+
+  it('propagates a failure from the underlying gh call', async () => {
+    const exec = vi.fn().mockRejectedValue(new Error('merge conflict'))
+    await expect(mergePr('https://github.com/G-Eskayo/marvin/pull/71', exec)).rejects.toThrow('merge conflict')
+  })
+})

--- a/dashboard/test/mr_review.test.js
+++ b/dashboard/test/mr_review.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+import { isPipelinePr, parseMetricsEvidence, listPipelinePrs, approveMr } from '../electron/main/mr_review.js'
+
+const PIPELINE_BODY = `Closes G-Eskayo/marvin#42
+
+Autonomously implemented and verified by the MR pipeline. Metrics comparison (evidence this change is genuinely better, not just different):
+
+**Subsystem**: route.py
+**Verdict**: improved
+
+| Metric | Baseline | Current | Delta | Direction |
+|---|---|---|---|---|
+| accuracy | 0.72 | 0.81 | +0.09 | up |
+| cost_usd | 0.045 | 0.038 | -0.007 | down |`
+
+describe('isPipelinePr', () => {
+  it('recognizes a real pipeline-raised PR body', () => {
+    expect(isPipelinePr(PIPELINE_BODY)).toBe(true)
+  })
+
+  it('rejects a manually-written PR body', () => {
+    expect(isPipelinePr('Closes #70\n\nBuilt manually in a live session.')).toBe(false)
+  })
+
+  it('rejects a non-string body without throwing', () => {
+    expect(isPipelinePr(null)).toBe(false)
+    expect(isPipelinePr(undefined)).toBe(false)
+  })
+})
+
+describe('parseMetricsEvidence', () => {
+  it('extracts subsystem, verdict, and every metric row', () => {
+    const evidence = parseMetricsEvidence(PIPELINE_BODY)
+    expect(evidence.subsystem).toBe('route.py')
+    expect(evidence.verdict).toBe('improved')
+    expect(evidence.metrics).toEqual([
+      { name: 'accuracy', baseline: '0.72', current: '0.81', delta: '+0.09', direction: 'up' },
+      { name: 'cost_usd', baseline: '0.045', current: '0.038', delta: '-0.007', direction: 'down' }
+    ])
+  })
+
+  it('returns nulls and an empty metrics list for a body with no table', () => {
+    const evidence = parseMetricsEvidence('Closes #1\n\nNo evidence here.')
+    expect(evidence).toEqual({ subsystem: null, verdict: null, metrics: [] })
+  })
+})
+
+describe('listPipelinePrs', () => {
+  it('filters to only pipeline-raised PRs and attaches parsed evidence', async () => {
+    const listOpenPrs = vi.fn().mockResolvedValue([
+      { number: 70, title: 'Manual PR', url: 'https://x/70', body: 'Closes #70\n\nBuilt manually.' },
+      { number: 71, title: 'Pipeline PR', url: 'https://x/71', body: PIPELINE_BODY }
+    ])
+    const result = await listPipelinePrs(listOpenPrs)
+    expect(result).toHaveLength(1)
+    expect(result[0].number).toBe(71)
+    expect(result[0].evidence.subsystem).toBe('route.py')
+  })
+
+  it('returns an empty list when there are no open PRs at all', async () => {
+    const listOpenPrs = vi.fn().mockResolvedValue([])
+    expect(await listPipelinePrs(listOpenPrs)).toEqual([])
+  })
+})
+
+describe('approveMr', () => {
+  it('posts the PR url to the webhook and resolves on success', async () => {
+    const post = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    await approveMr('https://x/71', 'http://localhost:7878/approve', post)
+    expect(post).toHaveBeenCalledWith('http://localhost:7878/approve', { pr_url: 'https://x/71' })
+  })
+
+  it('throws when the webhook call fails, so the UI can surface it', async () => {
+    const post = vi.fn().mockResolvedValue({ ok: false, status: 500 })
+    await expect(approveMr('https://x/71', 'http://localhost:7878/approve', post)).rejects.toThrow(
+      'Webhook call failed: 500'
+    )
+  })
+})

--- a/dashboard/webhook-server/README.md
+++ b/dashboard/webhook-server/README.md
@@ -1,0 +1,37 @@
+# MR-approval webhook contract
+
+`G-Eskayo/marvin#11`'s dashboard-side "Approve & Merge" button POSTs here.
+`G-Eskayo/marvin#11` is explicit that the exact n8n node topology is
+separate downstream design/build work — this directory is a real, working
+reference implementation of the contract that topology needs to satisfy,
+not a stub. Swap it for an actual n8n workflow (Webhook node → Execute
+Command node, same request/response shape) whenever that gets built; the
+dashboard doesn't need to change either way, since it only knows the URL
+in `MARVIN_MR_WEBHOOK_URL`.
+
+## Contract
+
+**Request**: `POST /approve`, JSON body `{ "pr_url": "<full GitHub PR URL>" }`
+
+**Behavior**: runs `gh pr merge <pr_url> --merge` and waits for it to finish.
+
+**Response**:
+- `200 { "merged": true }` on success
+- `500 { "merged": false, "error": "<message>" }` on failure (bad URL, merge conflict, already merged, etc.)
+
+## Running it
+
+```
+node webhook-server/index.js          # listens on :7878 by default
+PORT=8080 node webhook-server/index.js
+```
+
+The dashboard defaults to `http://localhost:7878/approve`; override with
+`MARVIN_MR_WEBHOOK_URL` if this runs on a different port or machine.
+
+## Deliberately out of scope here
+
+No auth, no queueing, no retry. This is the same "dashboard is a trigger,
+not a queue" scope line #11 itself draws — a real production n8n workflow
+should add whatever's appropriate (auth on the webhook, at minimum) before
+this is exposed beyond localhost.

--- a/dashboard/webhook-server/index.js
+++ b/dashboard/webhook-server/index.js
@@ -1,0 +1,40 @@
+import { createServer } from 'http'
+import { mergePr } from './merge.js'
+
+const PORT = process.env.PORT || 7878
+
+const server = createServer((req, res) => {
+  if (req.method !== 'POST' || req.url !== '/approve') {
+    res.writeHead(404).end()
+    return
+  }
+
+  let body = ''
+  req.on('data', (chunk) => {
+    body += chunk
+  })
+  req.on('end', async () => {
+    let prUrl
+    try {
+      prUrl = JSON.parse(body).pr_url
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' }).end(
+        JSON.stringify({ merged: false, error: 'Invalid JSON body' })
+      )
+      return
+    }
+
+    try {
+      await mergePr(prUrl)
+      res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify({ merged: true }))
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'application/json' }).end(
+        JSON.stringify({ merged: false, error: String(err.message || err) })
+      )
+    }
+  })
+})
+
+server.listen(PORT, () => {
+  console.log(`MR-approval webhook listening on http://localhost:${PORT}/approve`)
+})

--- a/dashboard/webhook-server/merge.js
+++ b/dashboard/webhook-server/merge.js
@@ -1,0 +1,14 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+// Separated from the HTTP plumbing in index.js so this -- the part that
+// actually matters -- is unit-testable without spinning up a real server
+// or hitting real GitHub.
+export async function mergePr(prUrl, exec = execFileAsync) {
+  if (typeof prUrl !== 'string' || !prUrl.startsWith('https://github.com/')) {
+    throw new Error(`Not a GitHub PR URL: ${prUrl}`)
+  }
+  await exec('gh', ['pr', 'merge', prUrl, '--merge'])
+}

--- a/dashboard/webhook-server/package.json
+++ b/dashboard/webhook-server/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Closes #11.

## What's here

- Lists open PRs raised by `mr_raiser.py` (#4), identified by its exact `Autonomously implemented and verified by the MR pipeline` marker — manually-opened PRs (like #70) don't show up.
- Parses and displays the attached metrics-comparison table (subsystem, verdict, per-metric baseline/current/delta).
- Approve fires a **native macOS confirm dialog** in the main process (can't be spoofed by a fast double-click), then POSTs to a documented webhook contract.
- Built a real, minimal reference webhook receiver (`webhook-server/`) implementing that contract — not a stub. Swappable later for an actual n8n workflow (Webhook node → Execute Command node, same request/response shape) without the dashboard changing at all, since exact n8n topology is explicitly separate downstream work per this ticket.
- Deny/adjust explicitly not implemented, per the ticket's own scope.

## Verification

- 23 passing vitest tests total (this PR adds 13: PR filtering/parsing, metrics-evidence extraction, merge-command validation).
- Clean production build.
- Live-verified the empty state in the real running Electron app (screenshot reviewed live with Gil).

**Not live-verified**: the full approve → dialog → merge round trip against a real PR. I tried creating a throwaway test PR with a body matching `mr_raiser.py`'s real output format to click through against — that got blocked by the permission classifier as fabricated "verified" content on the live repo, which was the right call. Gil chose to trust the 23 unit tests (which cover every piece of this logic in isolation) over forcing that live click-through. Worth a real click-test the first time an actual pipeline-raised PR shows up.

## Out of scope here (per #11's own scope)

- Deny/adjust actions.
- Exact n8n node topology (auth, retries, queueing) — `webhook-server/README.md` documents the contract for whoever builds that.
