### PR TITLE
paper_graph: rebuttal-survives-the-cap test coverage for blended relevance (ADR 0011)

### DIFF
--- a/skills/paper-dive/scripts/paper_graph.py
+++ b/skills/paper-dive/scripts/paper_graph.py
@@ -111,6 +111,11 @@ def _cosine_similarity(a: list[float], b: list[float]) -> float:
 
 
 def blended_score(seed_embeddings: dict, candidate_embeddings: dict, specter2_weight: float = 0.5) -> float:
+    """Weighted blend of SPECTER2 (citation-graph-aware) and nomic-embed (pure topical
+    similarity), per ADR 0011 -- not SPECTER2 alone. Hedges against SPECTER2's documented
+    citation-clique bias, which can under-rank a topically-relevant cross-camp rebuttal or
+    competing paper that doesn't cite/get cited within the seed's own citation community.
+    specter2_weight=0.5 is a starting point (ADR 0011: not yet empirically tuned)."""
     specter2_sim = _cosine_similarity(seed_embeddings["specter2"], candidate_embeddings["specter2"])
     nomic_sim = _cosine_similarity(seed_embeddings["nomic"], candidate_embeddings["nomic"])
     return specter2_weight * specter2_sim + (1 - specter2_weight) * nomic_sim

--- a/skills/paper-dive/scripts/tests/test_paper_graph.py
+++ b/skills/paper-dive/scripts/tests/test_paper_graph.py
@@ -26,6 +26,8 @@ from paper_graph import (
     _get_with_retry,
     _s2_id,
     _check_huggingface_reachable,
+    _cosine_similarity,
+    _shape_and_score,
 )
 
 LIB = Path.home() / ".agents" / "lib"
@@ -331,6 +333,48 @@ def test_blended_score_actually_blends_both_sources():
 
 
 # ── embed_paper (injected backends — no real model calls in the fast suite) ─
+
+def test_blended_score_rescues_cross_camp_rebuttal_specter2_alone_would_drop():
+    # ADR 0011's scenario: a competing/rebuttal paper from a different citation
+    # community. SPECTER2 (citation-clique-aware) under-ranks it below the
+    # relevance floor; nomic-embed (pure topical similarity) correctly reads it
+    # as on-topic. The blend, not SPECTER2 alone, is what survives the cap.
+    relevance_floor = 0.65
+    seed = {"specter2": [1.0, 0.0], "nomic": [1.0, 0.0]}
+    rebuttal = {
+        "specter2": [0.5, 0.8660254037844386],  # cos = 0.5 -- below floor alone
+        "nomic": [0.9, 0.4358898943540674],  # cos = 0.9 -- clearly on-topic
+    }
+
+    specter2_only_score = _cosine_similarity(seed["specter2"], rebuttal["specter2"])
+    blended = blended_score(seed, rebuttal, specter2_weight=0.5)
+
+    assert specter2_only_score < relevance_floor  # SPECTER2 alone would drop it
+    assert blended == pytest.approx(0.7)
+    assert blended >= relevance_floor  # the blend survives the cap
+
+
+def test_shape_and_score_selects_cross_camp_rebuttal_that_specter2_alone_would_cap_out(monkeypatch):
+    # End-to-end through the real selection path (_shape_and_score -> select_candidates),
+    # not just the raw blended_score number -- confirms the rebuttal actually survives
+    # relevance-floor filtering in the traversal, matching issue #24's acceptance criterion.
+    seed_embeddings = {"specter2": [1.0, 0.0], "nomic": [1.0, 0.0]}
+
+    def fake_embed(abstract):
+        return {"specter2": [0.5, 0.8660254037844386], "nomic": [0.9, 0.4358898943540674]}
+
+    papers = [{
+        "title": "Rebuttal from a rival research tradition",
+        "abstract": "disputes the seed's findings from an independently-derived angle",
+        "externalIds": {"DOI": "10.1/rebuttal"},
+    }]
+
+    candidates = _shape_and_score(papers, seed_embeddings, fake_embed, is_citation=False)
+    assert candidates[0]["score"] == pytest.approx(0.7)
+
+    selected = select_candidates(candidates, top_k=5, relevance_floor=0.65)
+    assert [c["doi"] for c in selected] == ["10.1/rebuttal"]
+
 
 def test_embed_paper_wires_injected_backends_into_expected_shape():
     result = embed_paper(


### PR DESCRIPTION
## Summary

Closes #24. The SPECTER2 + nomic-embed blend itself (`blended_score`, `embed_paper`, wired through `_shape_and_score`) was already implemented as part of #20's initial traversal work -- same day ADR 0011 was accepted, in commit 15831d2. What was missing was test coverage for issue #24's second acceptance criterion.

- **Criterion 1** ("documented blend, not either alone"): already true in code (module docstring references ADR 0007-0011; `blended_score` combines both sources by default). Added an explicit ADR-0011 docstring directly on `blended_score` so this is unambiguous rather than only implied by the module header.
- **Criterion 2** ("a known rebuttal/competing-paper test case scores high enough to survive the cap that SPECTER2-only would have dropped"): had no test. Added two:
  - `test_blended_score_rescues_cross_camp_rebuttal_specter2_alone_would_drop` -- SPECTER2-alone cosine = 0.5 (below the 0.65 relevance floor), nomic-embed cosine = 0.9 (clearly on-topic), blended = 0.7 (clears the floor).
  - `test_shape_and_score_selects_cross_camp_rebuttal_that_specter2_alone_would_cap_out` -- same scenario end-to-end through `_shape_and_score` -> `select_candidates`, confirming the rebuttal actually survives relevance-floor filtering in the real selection path, not just as a raw score comparison.

## Test plan

- [x] `~/.agents/venv/bin/python -m pytest skills/paper-dive/scripts/tests/test_paper_graph.py -v` -- 35/35 passed (33 pre-existing + 2 new)
- [x] Reviewed diff manually (this dispatch's Bash allowlist blocked `git diff`; reviewed the Edit tool's own diff output instead)

## Notes for the merger

No file overlap with the currently open PRs (#88, #87, #86, #85, #84, #83) -- all touch the dashboard/MR-review app, not `skills/paper-dive/`. Safe to merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
