### PR TITLE
paper_graph: explicit test coverage for checkpoint's queue-state report (ADR 0010)

### DIFF
--- a/skills/paper-dive/scripts/paper_graph.py
+++ b/skills/paper-dive/scripts/paper_graph.py
@@ -334,6 +334,8 @@ def traverse(
     recent_scores: list[float] = []
 
     def ceiling_hit() -> bool:
+        """ADR 0010: report queue state at the checkpoint (not just a bare
+        pause) so continue/stop is an informed decision, not a guess."""
         if cost_ceiling is None or on_checkpoint is None:
             return False
         if len(results) < cost_ceiling + 1:

--- a/skills/paper-dive/scripts/tests/test_paper_graph.py
+++ b/skills/paper-dive/scripts/tests/test_paper_graph.py
@@ -279,6 +279,48 @@ def test_traverse_continues_past_ceiling_when_checkpoint_says_continue():
     assert {n["doi"] for n in result} == {"seed", "n1", "n2", "n3"}
 
 
+def test_traverse_checkpoint_receives_accurate_queue_state():
+    # ADR 0010 requires the checkpoint to report queue state (not just pause silently) so
+    # continue/stop is an informed decision -- this pins down exactly what gets reported.
+    graph = {
+        "seed": {
+            "references": [
+                {"doi": "n1", "score": 0.9, "intent": None},
+                {"doi": "n2", "score": 0.85, "intent": None},
+                {"doi": "n3", "score": 0.8, "intent": None},
+            ],
+            "citations": [],
+        },
+        "n1": {"references": [], "citations": []},
+        "n2": {"references": [], "citations": []},
+        "n3": {"references": [], "citations": []},
+    }
+
+    def fake_fetch(doi):
+        return graph[doi]
+
+    seen_states = []
+
+    def spy_checkpoint(state):
+        seen_states.append(state)
+        return "stop"
+
+    traverse(
+        seed_doi="seed",
+        fetch_fn=fake_fetch,
+        max_depth=2,
+        references_top_k=10,
+        citations_top_k=5,
+        relevance_floor=0.5,
+        cost_ceiling=1,
+        on_checkpoint=spy_checkpoint,
+    )
+
+    # ceiling=1 is hit right after n1 is accepted (seed + n1 = 2 nodes so far), with n1
+    # itself still sitting in the queue unexpanded, and n2 not yet checked against the ceiling
+    assert seen_states == [{"nodes_so_far": 2, "queue_size": 1}]
+
+
 def test_traverse_stops_early_via_diminishing_returns_without_hitting_ceiling():
     # scores hover right at the floor from the very first hop — should self-terminate
     # long before the (deliberately generous) cost_ceiling would ever matter.


### PR DESCRIPTION
## Summary

Closes #23. The checkpoint-and-confirm stopping heuristic itself was already implemented as part of #20's initial traversal work -- same day ADR 0010 was accepted, in commit 15831d2. This mirrors what PR #98 found for the sibling ticket #24: the underlying mechanism predates the issue's own filing, so the real remaining gap was test coverage, not new behavior.

- **AC1** ("stops on a measured diminishing-returns trend, not a fixed node count"): already true and already tested (`diminishing_returns()`, `test_diminishing_returns_*`, `test_traverse_stops_early_via_diminishing_returns_without_hitting_ceiling`).
- **AC2** ("cost-ceiling checkpoint pauses and reports queue state + asks continue/extend/stop before any silent truncation"): the stop/continue *behavior* was already tested (`test_traverse_stops_at_cost_ceiling_when_checkpoint_says_stop`, `test_traverse_continues_past_ceiling_when_checkpoint_says_continue`), but nothing asserted on the actual *reported queue state* -- the `{"nodes_so_far", "queue_size"}` dict passed to `on_checkpoint`. Added `test_traverse_checkpoint_receives_accurate_queue_state`, which pins down the exact values reported at the moment the ceiling fires, plus a short docstring on `ceiling_hit()` pointing back at ADR 0010 so the contract is explicit in code, not just in the ADR.

No behavior change -- test-only addition (+1 line docstring) confirming existing code already meets both acceptance criteria.

## Notes for the merger

- **Order matters with PR #98** (`agent/issue-24`, still open): both PRs touch `skills/paper-dive/scripts/paper_graph.py` and `.../tests/test_paper_graph.py`. No line overlap (my change is in the checkpoint/`ceiling_hit` section; #98's is in the `blended_score` section), so it should merge cleanly in either order, but worth merging one before rebasing the other to avoid a stale base.
- No overlap with the other open PRs (#88, #87, #86, #85, #84) -- those touch the dashboard/MR-review app, not `skills/paper-dive/`.
- ADR 0010's prose says the checkpoint should offer "continue, extend, or stop"; the shipped CLI (`_confirm_checkpoint`, unchanged by this PR) only distinguishes continue vs. stop (`[y/N/more]`, where "more" maps to continue). I left this as-is rather than inventing new three-way state-machine semantics not requested by the issue's acceptance criteria -- flagging it here in case it's worth a follow-up ticket.

## Test plan

- [x] `~/.agents/venv/bin/python -m pytest skills/paper-dive/scripts/tests/test_paper_graph.py -v` -- 34/34 passed (33 pre-existing + 1 new)
- [x] `~/.agents/venv/bin/python -m pytest skills/paper-dive/scripts/tests/ -q` -- full paper-dive suite, 127/127 passed
- [x] Manually traced `traverse()`'s heap/results state step-by-step against the new test's fixture to confirm the asserted `{"nodes_so_far": 2, "queue_size": 1}` is correct, not just something the code happens to produce

🤖 Generated with [Claude Code](https://claude.com/claude-code)
