### PR TITLE
bench: guard mlx_lm_eval_adapter's _register() against missing lm_eval

### DIFF
--- a/bench/lib/mlx_lm_eval_adapter.py
+++ b/bench/lib/mlx_lm_eval_adapter.py
@@ -73,4 +73,7 @@ def _register():
     return MLXInProcessLM
 
 
-_register()
+try:
+    _register()
+except ImportError:
+    pass

--- a/bench/lib/tests/test_mlx_lm_eval_adapter.py
+++ b/bench/lib/tests/test_mlx_lm_eval_adapter.py
@@ -14,6 +14,7 @@ LIB = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(LIB))
 
 import pytest
+pytest.importorskip("lm_eval")
 from mlx_lm_eval_adapter import score_continuation
 
 


### PR DESCRIPTION
Found incidentally while dispatching #21 (bidirectional traversal with asymmetric caps for paper-graph) -- the build-type measure() step runs the repo-wide pytest suite, and collection was failing repo-wide because `bench/lib/mlx_lm_eval_adapter.py`'s module-level `_register()` call crashes on import when `lm_eval` isn't installed. This PR does NOT implement #21 -- that ticket's claim has been released and it's back in the queue for a real attempt (see comment on #21).

## Metrics Comparison

**Subsystem**: ticket-21
**Verdict**: improved

| Metric | Baseline | Current | Delta | Direction |
|---|---|---|---|---|
| tests_passing | 0.0 | 1.0 | +1.0 | improved |

## Test Results

**Suite**: /Users/gileskayo/.agents/venv/bin/python -m pytest -q
**Passed**: 376
**Failed**: 0
**Total**: 376

## Dev Environment Evidence

N/A — no UI