### PR TITLE
Implement G-Eskayo/marvin#20

### DIFF
--- a/skills/paper-dive/SKILL.md
+++ b/skills/paper-dive/SKILL.md
@@ -146,8 +146,10 @@ citations (forward, situational context, including likely rebuttals via a `resul
 bypass) — ordered by relevance to the seed via a blended SPECTER2 + nomic-embed score, not plain
 breadth/depth-first order. Stores every paper found in the shared `paper-knowledge` ChromaDB
 collection (`~/.claude/chroma`), deduplicated across all past investigations, not just within one
-run. If the traversal's cost ceiling is reached before it naturally runs out of relevant papers to
-find, it pauses and asks whether to keep going rather than silently stopping.
+run. Already-known papers are skipped entirely during traversal: no S2 fetch, no embedding, no
+queue expansion — they're treated as dead ends for this run. If the traversal's cost ceiling is
+reached before it naturally runs out of relevant papers to find, it pauses and asks whether to
+keep going rather than silently stopping.
 Design record: `~/.agents/docs/adr/0007`–`0011`.
 
 **Known gotcha**: the blended SPECTER2 + nomic-embed score ranks by semantic similarity, not

--- a/skills/paper-dive/scripts/paper_graph.py
+++ b/skills/paper-dive/scripts/paper_graph.py
@@ -197,7 +197,7 @@ def embed_paper(text: str, specter2_fn=None, nomic_fn=None) -> dict:
 S2_PAPER_BASE = "https://api.semanticscholar.org/graph/v1/paper"
 
 
-def _shape_and_score(papers: list[dict], seed_embeddings: dict, embed_fn, is_citation: bool) -> list[dict]:
+def _shape_and_score(papers: list[dict], seed_embeddings: dict, embed_fn, is_citation: bool, is_known_fn=None) -> list[dict]:
     candidates = []
     for p in papers:
         external_ids = p.get("externalIds") or {}
@@ -210,6 +210,8 @@ def _shape_and_score(papers: list[dict], seed_embeddings: dict, embed_fn, is_cit
         abstract = p.get("abstract") or p.get("title") or ""
         if not doi or not abstract:
             continue
+        if is_known_fn is not None and is_known_fn(doi):
+            continue
         candidate_embeddings = embed_fn(abstract)
         score = blended_score(seed_embeddings, candidate_embeddings)
         intent = "result" if is_citation and "result" in (p.get("intents") or []) else None
@@ -217,7 +219,7 @@ def _shape_and_score(papers: list[dict], seed_embeddings: dict, embed_fn, is_cit
     return candidates
 
 
-def fetch_neighbors_from_s2(doi: str, seed_embeddings: dict, embed_fn=None) -> dict:
+def fetch_neighbors_from_s2(doi: str, seed_embeddings: dict, embed_fn=None, is_known_fn=None) -> dict:
     import time
     import requests
 
@@ -231,12 +233,12 @@ def fetch_neighbors_from_s2(doi: str, seed_embeddings: dict, embed_fn=None) -> d
     time.sleep(0.5)  # rate-limit courtesy, same pattern as fetch_related.py
 
     return {
-        "references": _shape_and_score(data.get("references") or [], seed_embeddings, embed_fn, is_citation=False),
-        "citations": _shape_and_score(data.get("citations") or [], seed_embeddings, embed_fn, is_citation=True),
+        "references": _shape_and_score(data.get("references") or [], seed_embeddings, embed_fn, is_citation=False, is_known_fn=is_known_fn),
+        "citations": _shape_and_score(data.get("citations") or [], seed_embeddings, embed_fn, is_citation=True, is_known_fn=is_known_fn),
     }
 
 
-def fetch_neighbors_by_search(query_text: str, seed_embeddings: dict, embed_fn=None) -> dict:
+def fetch_neighbors_by_search(query_text: str, seed_embeddings: dict, embed_fn=None, is_known_fn=None) -> dict:
     """For an unpublished/non-indexed seed: S2 has no record to fetch 'its' references/citations
     from, so this finds candidate related papers via full-text search instead. Only feeds the
     references bucket — there's no way to discover citations of a paper S2 doesn't know exists."""
@@ -249,7 +251,7 @@ def fetch_neighbors_by_search(query_text: str, seed_embeddings: dict, embed_fn=N
         timeout=15,
     )
     data = resp.json()
-    references = _shape_and_score(data.get("data") or [], seed_embeddings, embed_fn, is_citation=False)
+    references = _shape_and_score(data.get("data") or [], seed_embeddings, embed_fn, is_citation=False, is_known_fn=is_known_fn)
     return {"references": references, "citations": []}
 
 
@@ -279,9 +281,12 @@ def run_paper_graph(
         embed_fn = embed_fn or embed_paper
         seed_embeddings = embed_fn(seed_abstract)
 
+    is_known_fn = None
     if fetch_fn is None:
+        is_known_fn = lambda doi: is_known(doi, collection)
+
         def fetch_fn(doi):
-            return fetch_neighbors_from_s2(doi, seed_embeddings, embed_fn=embed_fn)
+            return fetch_neighbors_from_s2(doi, seed_embeddings, embed_fn=embed_fn, is_known_fn=is_known_fn)
 
     if is_unpublished:
         base_fetch_fn = fetch_fn
@@ -289,7 +294,10 @@ def run_paper_graph(
 
         def fetch_fn(doi):  # noqa: F811 — deliberate shadow: dispatches seed vs. everything else
             if doi == seed_id:
-                return do_search(seed_search_query, seed_embeddings, embed_fn)
+                if search_fetch_fn is None:
+                    return do_search(seed_search_query, seed_embeddings, embed_fn, is_known_fn=is_known_fn)
+                else:
+                    return do_search(seed_search_query, seed_embeddings, embed_fn)
             return base_fetch_fn(doi)
 
     results = traverse(

--- a/skills/paper-dive/scripts/tests/test_paper_graph.py
+++ b/skills/paper-dive/scripts/tests/test_paper_graph.py
@@ -823,3 +823,140 @@ def test_shape_and_score_selects_cross_camp_rebuttal_that_specter2_alone_would_c
     assert candidates[0]["doi"] == "10.1/rebuttal"
     assert candidates[0]["intent"] == "result"
     assert candidates[0]["score"] == pytest.approx(0.5)  # blended score, not 0.0
+
+
+# ── AC2: skip already-known papers (embedding + fetch) ───────────────────────
+
+def test_shape_and_score_skips_already_known_candidates_without_embedding():
+    # AC2: Known DOIs should skip embedding entirely, not just skip re-recording.
+    seed_embeddings = {"specter2": [1.0, 0.0], "nomic": [1.0, 0.0]}
+    papers = [
+        {"title": "Known", "abstract": "already in collection", "externalIds": {"DOI": "10.1/known"}},
+        {"title": "Unknown", "abstract": "new paper", "externalIds": {"DOI": "10.1/unknown"}},
+    ]
+
+    embed_calls = []
+
+    def spy_embed(text):
+        embed_calls.append(text)
+        return {"specter2": [1.0, 0.0], "nomic": [1.0, 0.0]}
+
+    def fake_is_known(doi):
+        return doi == "10.1/known"
+
+    candidates = _shape_and_score(
+        papers,
+        seed_embeddings,
+        embed_fn=spy_embed,
+        is_citation=False,
+        is_known_fn=fake_is_known,
+    )
+
+    # only unknown paper should be embedded and returned
+    assert len(candidates) == 1
+    assert candidates[0]["doi"] == "10.1/unknown"
+    assert len(embed_calls) == 1
+    assert embed_calls[0] == "new paper"
+
+
+def test_fetch_neighbors_from_s2_filters_out_known_candidates(monkeypatch):
+    # AC2: fetch_neighbors_from_s2 should skip embedding and exclude known DOIs from results.
+    s2_payload = {
+        "references": [
+            {"title": "Known Ref", "abstract": "already known", "externalIds": {"DOI": "10.1/ref-known"}},
+            {"title": "New Ref", "abstract": "new reference", "externalIds": {"DOI": "10.1/ref-new"}},
+        ],
+        "citations": [
+            {"title": "Known Cite", "abstract": "already known", "externalIds": {"DOI": "10.1/cite-known"}, "intents": []},
+            {"title": "New Cite", "abstract": "new citation", "externalIds": {"DOI": "10.1/cite-new"}, "intents": []},
+        ],
+    }
+
+    def fake_get(url, params=None, timeout=None, headers=None):
+        return _FakeResponse(s2_payload)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    seed_embeddings = {"specter2": [1.0, 0.0], "nomic": [1.0, 0.0]}
+
+    embed_calls = []
+
+    def spy_embed(text, specter2_fn=None, nomic_fn=None):
+        embed_calls.append(text)
+        return {"specter2": [1.0, 0.0], "nomic": [1.0, 0.0]}
+
+    def fake_is_known(doi):
+        return doi.endswith("-known")
+
+    result = fetch_neighbors_from_s2(
+        doi="10.1/seed",
+        seed_embeddings=seed_embeddings,
+        embed_fn=spy_embed,
+        is_known_fn=fake_is_known,
+    )
+
+    # only new papers should be in results and embedded
+    ref_dois = {c["doi"] for c in result["references"]}
+    cite_dois = {c["doi"] for c in result["citations"]}
+    assert ref_dois == {"10.1/ref-new"}
+    assert cite_dois == {"10.1/cite-new"}
+    assert len(embed_calls) == 2
+    assert "new reference" in embed_calls
+    assert "new citation" in embed_calls
+
+
+def test_run_paper_graph_skips_embedding_already_known_candidates_end_to_end(monkeypatch, tmp_path):
+    # AC2 end-to-end: pre-seed the collection with a candidate DOI, verify it's
+    # never embedded and never explored in the traversal.
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.get_or_create_collection("paper-knowledge")
+
+    # Pre-record a candidate DOI so it's "known"
+    record_paper(
+        collection,
+        doi="10.1/known-candidate",
+        abstract="this was found before",
+        discovered_via=None,
+    )
+
+    embed_calls = []
+
+    def spy_embed(text, specter2_fn=None, nomic_fn=None):
+        embed_calls.append(text)
+        return {"specter2": [1.0, 0.0], "nomic": [1.0, 0.0]}
+
+    # Mock S2 API to return our test data
+    s2_payload = {
+        "references": [
+            {"title": "Known", "abstract": "known abstract", "externalIds": {"DOI": "10.1/known-candidate"}},
+            {"title": "New", "abstract": "new abstract", "externalIds": {"DOI": "10.1/new-candidate"}},
+        ],
+        "citations": [],
+    }
+
+    def fake_get(url, params=None, timeout=None, headers=None):
+        return _FakeResponse(s2_payload)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    results = run_paper_graph(
+        seed_doi="10.1/seed",
+        seed_abstract="the seed paper's abstract",
+        collection=collection,
+        max_depth=1,
+        references_top_k=10,
+        citations_top_k=5,
+        relevance_floor=0.5,
+        embed_fn=spy_embed,
+    )
+
+    # AC2: known-candidate should be filtered out during traversal entirely (never added to results,
+    # never embedded, never queued for further exploration). Only seed and new-candidate should be present.
+    result_dois = {n["doi"] for n in results}
+    assert result_dois == {"10.1/seed", "10.1/new-candidate"}
+
+    # only seed and new-candidate should be embedded; known-candidate never touched
+    embedded_texts = embed_calls
+    assert "the seed paper's abstract" in embedded_texts
+    assert "new abstract" in embedded_texts
+    assert "known abstract" not in embedded_texts  # never embedded


### PR DESCRIPTION
Closes G-Eskayo/marvin#20

Autonomously implemented and verified by the MR pipeline.

## Metrics Comparison

**Subsystem**: ticket-20
**Verdict**: improved

| Metric | Baseline | Current | Delta | Direction |
|---|---|---|---|---|
| tests_failed | 0 | 0 | +0 | unchanged |
| tests_passed | 424 | 427 | +3 | improved |

## Test Results

**Suite**: /Users/gileskayo/.agents/venv/bin/python -m pytest -q
**Passed**: 427
**Failed**: 0
**Total**: 427

## Dev Environment Evidence

N/A — no UI