### PR TITLE
Implement G-Eskayo/marvin#22

### DIFF
--- a/skills/paper-dive/scripts/paper_graph.py
+++ b/skills/paper-dive/scripts/paper_graph.py
@@ -75,6 +75,17 @@ def is_known(doi: str, collection) -> bool:
     return len(result["ids"]) > 0
 
 
+def get_discovery(collection, doi: str) -> dict | None:
+    """Returns the first-discovery record ({parent_doi, edge_type, hop_depth}) for doi, or None if doi is unknown or is a seed (no parent)."""
+    result = collection.get(ids=[doi], include=["metadatas"])
+    if not result["ids"]:
+        return None
+    meta = result["metadatas"][0]
+    if "parent_doi" not in meta:
+        return None
+    return {"parent_doi": meta["parent_doi"], "edge_type": meta["edge_type"], "hop_depth": meta["hop_depth"]}
+
+
 def record_paper(collection, doi: str, abstract: str, discovered_via: dict | None) -> None:
     import time
 
@@ -419,6 +430,7 @@ def main() -> None:
     ap = argparse.ArgumentParser(description="Recursive citation-graph traversal from a seed paper (paper-dive).")
     ap.add_argument("--doi", help="DOI of the seed paper (skips session/slug lookup entirely)")
     ap.add_argument("--slug", help="Session slug — reads DOI/title/text from that session's state.json + raw.md")
+    ap.add_argument("--show-discovery", help="Query first-discovery metadata for a DOI and exit")
     ap.add_argument("--depth", type=int, default=2, help="Max hop depth (default: 2)")
     ap.add_argument("--references-top-k", type=int, default=10)
     ap.add_argument("--citations-top-k", type=int, default=5)
@@ -426,6 +438,22 @@ def main() -> None:
     ap.add_argument("--cost-ceiling", type=int, default=100)
     ap.add_argument("--diminishing-returns-window", type=int, default=5)
     args = ap.parse_args()
+
+    import chromadb
+
+    client = chromadb.PersistentClient(path=str(CHROMA_PATH))
+    collection = client.get_or_create_collection(PAPER_KNOWLEDGE_COLLECTION)
+
+    if args.show_discovery:
+        discovery = get_discovery(collection, args.show_discovery)
+        if discovery is None:
+            print(f"No discovery record for {args.show_discovery}")
+        else:
+            print(f"First discovery of {args.show_discovery}:")
+            print(f"  parent_doi: {discovery['parent_doi']}")
+            print(f"  edge_type: {discovery['edge_type']}")
+            print(f"  hop_depth: {discovery['hop_depth']}")
+        raise SystemExit(0)
 
     doi = args.doi
     slug = args.slug
@@ -446,11 +474,6 @@ def main() -> None:
     if not doi and not slug:
         print("ERROR: provide --doi, or --slug (works for both published and unpublished/no-DOI sessions)")
         raise SystemExit(1)
-
-    import chromadb
-
-    client = chromadb.PersistentClient(path=str(CHROMA_PATH))
-    collection = client.get_or_create_collection(PAPER_KNOWLEDGE_COLLECTION)
 
     if doi:
         seed_abstract = seed_abstract or _fetch_seed_abstract(doi)

--- a/skills/paper-dive/scripts/tests/test_paper_graph.py
+++ b/skills/paper-dive/scripts/tests/test_paper_graph.py
@@ -15,6 +15,7 @@ import pytest
 from paper_graph import (
     select_candidates,
     is_known,
+    get_discovery,
     traverse,
     record_paper,
     diminishing_returns,
@@ -960,3 +961,116 @@ def test_run_paper_graph_skips_embedding_already_known_candidates_end_to_end(mon
     assert "the seed paper's abstract" in embedded_texts
     assert "new abstract" in embedded_texts
     assert "known abstract" not in embedded_texts  # never embedded
+
+
+# ── get_discovery (queryable first-discovery metadata) ────────────────────────
+
+def test_get_discovery_returns_parent_edge_and_hop_for_recorded_paper(tmp_path):
+    # AC2: get_discovery should return the first-discovery record for a non-seed paper.
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.get_or_create_collection("paper-knowledge")
+
+    record_paper(
+        collection,
+        doi="10.1/paper",
+        abstract="some abstract",
+        discovered_via={"parent_doi": "10.1/seed", "edge_type": "reference", "hop_depth": 1},
+    )
+
+    discovery = get_discovery(collection, "10.1/paper")
+    assert discovery is not None
+    assert discovery["parent_doi"] == "10.1/seed"
+    assert discovery["edge_type"] == "reference"
+    assert discovery["hop_depth"] == 1
+
+
+def test_get_discovery_returns_none_for_seed_paper(tmp_path):
+    # AC2: a seed paper (discovered_via=None) should return None from get_discovery.
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.get_or_create_collection("paper-knowledge")
+
+    record_paper(
+        collection,
+        doi="10.1/seed",
+        abstract="seed abstract",
+        discovered_via=None,
+    )
+
+    discovery = get_discovery(collection, "10.1/seed")
+    assert discovery is None
+
+
+def test_get_discovery_returns_none_for_unknown_doi(tmp_path):
+    # AC2: an unknown DOI should return None.
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.get_or_create_collection("paper-knowledge")
+
+    discovery = get_discovery(collection, "10.1/unknown")
+    assert discovery is None
+
+
+def test_run_paper_graph_preserves_first_discovery_only_on_rediscovery(tmp_path):
+    # ADR 0009 regression: "first discovery wins" — if a paper is discovered via one parent/edge
+    # in the first run and then re-encountered via a different parent/edge in a second run, the
+    # original first-discovery metadata should be preserved.
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.get_or_create_collection("paper-knowledge")
+
+    # First traversal: find "10.1/child" via "10.1/seed1" as a reference
+    graph1 = {
+        "10.1/seed1": {
+            "references": [{"doi": "10.1/child", "score": 0.9, "intent": None, "abstract": "child abstract"}],
+            "citations": [],
+        },
+    }
+
+    def fake_fetch1(doi):
+        return graph1[doi]
+
+    results1 = run_paper_graph(
+        seed_doi="10.1/seed1",
+        seed_abstract="seed1 abstract",
+        collection=collection,
+        max_depth=1,
+        references_top_k=10,
+        citations_top_k=5,
+        relevance_floor=0.5,
+        fetch_fn=fake_fetch1,
+    )
+
+    # Verify first discovery recorded
+    first_discovery = get_discovery(collection, "10.1/child")
+    assert first_discovery is not None
+    assert first_discovery["parent_doi"] == "10.1/seed1"
+    assert first_discovery["edge_type"] == "reference"
+
+    # Second traversal: if we somehow discover "10.1/child" again via a different parent,
+    # the first-discovery metadata should not be overwritten (it's already known)
+    # (In reality, is_known() filters it out before re-recording, but let's verify the
+    # behavior explicitly by checking that a second run doesn't change the metadata)
+    graph2 = {
+        "10.1/seed2": {
+            "references": [{"doi": "10.1/child", "score": 0.85, "intent": None, "abstract": "child abstract"}],
+            "citations": [],
+        },
+    }
+
+    def fake_fetch2(doi):
+        return graph2[doi]
+
+    results2 = run_paper_graph(
+        seed_doi="10.1/seed2",
+        seed_abstract="seed2 abstract",
+        collection=collection,
+        max_depth=1,
+        references_top_k=10,
+        citations_top_k=5,
+        relevance_floor=0.5,
+        fetch_fn=fake_fetch2,
+    )
+
+    # Verify first-discovery metadata was NOT changed (still points to original parent/edge)
+    still_first_discovery = get_discovery(collection, "10.1/child")
+    assert still_first_discovery is not None
+    assert still_first_discovery["parent_doi"] == "10.1/seed1"  # unchanged
+    assert still_first_discovery["edge_type"] == "reference"  # unchanged


### PR DESCRIPTION
Closes G-Eskayo/marvin#22

Autonomously implemented and verified by the MR pipeline.

## Metrics Comparison

**Subsystem**: ticket-22
**Verdict**: improved

| Metric | Baseline | Current | Delta | Direction |
|---|---|---|---|---|
| tests_passed | 431 | 435 | +4 | improved |
| tests_failed | 0 | 0 | +0 | unchanged |

## Test Results

**Suite**: /Users/gileskayo/.agents/venv/bin/python -m pytest -q
**Passed**: 435
**Failed**: 0
**Total**: 435

## Dev Environment Evidence

N/A — no UI