### PR TITLE
Implement G-Eskayo/marvin#25

### DIFF
--- a/docs/adr/0031-arxiv-only-full-text-fetch-for-high-relevance-nodes.md
+++ b/docs/adr/0031-arxiv-only-full-text-fetch-for-high-relevance-nodes.md
@@ -1,0 +1,76 @@
+# 0031 — arXiv-only full-text fetch for high-relevance nodes in paper-graph
+
+## Status
+
+Accepted (2026-08-31)
+
+## Context
+
+[[0007]]–[[0011]] establish paper-graph's recursive traversal, scoring candidates by
+relevance to a seed paper via blended SPECTER2 + nomic embedding. Candidates are stored in the
+`paper-knowledge` collection with their abstract as the document text.
+
+The traversal identifies papers worth including (score ≥ `relevance_floor`, default 0.65) but
+doesn't distinguish between *highly relevant* nodes (which might merit deeper analysis) and
+*barely included* nodes at the floor. When using these papers downstream (e.g., in `/compare`
+or synthesis workflows), abstract-only storage limits analysis — full text unlocks finer-grained
+claims, methodology, and counterarguments.
+
+Fetching full text for *every* node is expensive (API calls, storage, embedding complexity).
+Fetching it only for *high-relevance* nodes (a stricter threshold than inclusion) trades cost for
+benefit: the papers most likely to matter get full-text treatment.
+
+Sci-Hub was initially considered as a fallback source for DOI-only papers, but commit c3982a1
+(2026-08-29) deliberately removed Sci-Hub from the project's source list across all skills,
+with this reasoning: *"Sci-Hub is a shadow library that bypasses publisher paywalls to serve
+copyrighted papers without authorization, not an open-access or society-partnered source."*
+Implementing an automated Sci-Hub scraper as a permanent pipeline feature would contradict that
+decision and complicate the system without a clear policy change to support it.
+
+## Decision
+
+**Full-text fetch happens for high-relevance nodes with arXiv IDs only.** Specifically:
+
+1. **Two-tier relevance thresholds:**
+   - `relevance_floor` (default 0.65): minimum score for *inclusion* in the graph
+   - `full_text_threshold` (default 0.85): minimum score for *full-text fetch*
+   
+   Below-threshold nodes never trigger a fetch, even if they have arXiv IDs.
+
+2. **arXiv as the sole full-text source:**
+   - Nodes with arXiv IDs scoring ≥ `full_text_threshold` have their PDF fetched from
+     `https://arxiv.org/pdf/{arxiv_id}` and full text extracted via the same pipeline as
+     `ingest_paper.py` (importing `ingest_paper.extract_pdf()`).
+   - Nodes scoring ≥ `full_text_threshold` without arXiv IDs (DOI-only) store their abstract — no
+     fallback source, no Sci-Hub scraper.
+   - Fetch failures (404, network error, PDF parse failure) gracefully degrade to abstract-only
+     storage; they do not fail the traversal.
+
+3. **Metadata stamping:**
+   - `record_paper()` stores `full_text: bool` in ChromaDB metadata, making downstream code aware
+     whether a document is full-text or abstract-only.
+
+## Consequences
+
+- **Pro:** High-relevance papers now have full text available for downstream analysis. The
+  threshold split (inclusion vs. full-text) is explicit, testable, and tunable without rebuilding
+  the whole traversal.
+- **Pro:** arXiv-only scope is defensible and consistent with the project's existing stance on
+  open-access sources (see c3982a1).
+- **Pro:** Graceful degradation on fetch failure means one bad PDF or network hiccup doesn't
+  break the traversal.
+- **Con:** DOI-only high-relevance papers (journal articles without preprints) stay abstract-only.
+  If a significant proportion of relevant papers are DOI-only, full-text coverage will be
+  incomplete. This is a legitimate "no open-access source available" outcome, not a gap to
+  solve with unauthorized mirror sites.
+- **Con:** Chroma's default embedding function has a max input length; storing full text as
+  documents may get truncated on embedding even though the full text itself is preserved.
+  This is noted as a follow-up ticket on chunking if search quality suffers.
+- **Acceptance criterion:** AC1 (full-text fetched and run through extraction for high-relevance
+  arXiv nodes), AC2 (same extraction pipeline as ingest_paper), and AC3 (no fetch for
+  below-threshold nodes, no Sci-Hub fallback) are all met and tested.
+
+## Related ADRs
+
+- [[0007]] — greedy best-first citation traversal (the traversal heuristic itself)
+- [[0011]] — blended SPECTER2 + nomic embedding (relevance scoring)

--- a/skills/paper-dive/SKILL.md
+++ b/skills/paper-dive/SKILL.md
@@ -136,9 +136,9 @@ Run `scripts/fetch_related.py` with the paper's DOI or title+keywords. Returns:
 - 3–5 papers that contradict or challenge it
 - Ranked by citation count x recency score
 
-Sources queried in order: Semantic Scholar API -> arXiv -> scihub.org
+Sources queried in order: Semantic Scholar API -> arXiv
 
-### `/paper-graph [--depth N]`
+### `/paper-graph [--depth N] [--full-text-threshold T]`
 Recursive citation-graph traversal, building a persistent knowledge base rooted at the current
 paper (or `--slug` session's DOI). Run `scripts/paper_graph.py --slug [session-slug] --depth N`
 (default depth 2). Follows both directions — references (backward, primary-source backbone) and
@@ -150,7 +150,16 @@ run. Already-known papers are skipped entirely during traversal: no S2 fetch, no
 queue expansion — they're treated as dead ends for this run. If the traversal's cost ceiling is
 reached before it naturally runs out of relevant papers to find, it pauses and asks whether to
 keep going rather than silently stopping.
-Design record: `~/.agents/docs/adr/0007`–`0011`.
+
+**Full-text fetch for high-relevance nodes:** For nodes scoring ≥ `--full-text-threshold`
+(default 0.85, stricter than the inclusion floor of 0.65) that have arXiv IDs, paper-graph
+automatically fetches the full PDF from arXiv and extracts text via the same pipeline as
+ingest_paper.py, storing full text instead of abstract only. Nodes with arXiv IDs below the
+threshold remain abstract-only — no fetch is attempted. DOI-only papers (no arXiv ID) store their
+abstract regardless of score. Fetch failures (404, network error) gracefully degrade to
+abstract-only storage.
+
+Design records: `~/.agents/docs/adr/0007`–`0011`, `~/.agents/docs/adr/0031`.
 
 **Known gotcha**: the blended SPECTER2 + nomic-embed score ranks by semantic similarity, not
 domain correctness — it will occasionally surface a paper from a completely unrelated field (e.g.
@@ -202,8 +211,7 @@ synthesis.md    -- output of /synthesize (if run)
 ## Source Hierarchy for Related Papers
 
 1. **Semantic Scholar API** (`api.semanticscholar.org`) -- free, no key required for basic use. Best for citation graph traversal. Use `scripts/fetch_related.py`.
-2. **arXiv** (`arxiv.org`) -- preprints. CS, math, physics, ML. Free API.
-3. **Science Hub** (`scihub.org`) -- Giles' preferred source for journal-quality papers. High-quality open-access journals with society partners.
+2. **arXiv** (`arxiv.org`) -- preprints. CS, math, physics, ML. Free API. Full-text PDFs available via `/paper-graph` for high-relevance nodes.
 
 Always surface which source each paper came from. Note open-access status.
 

--- a/skills/paper-dive/scripts/paper_graph.py
+++ b/skills/paper-dive/scripts/paper_graph.py
@@ -13,6 +13,7 @@ works fine under 4.57.6 despite that declared constraint; the pin is kept at
 from __future__ import annotations
 import heapq
 import re
+import tempfile
 from pathlib import Path
 
 _ARXIV_ID_RE = re.compile(r"^\d{4}\.\d{4,5}(v\d+)?$")
@@ -86,7 +87,7 @@ def get_discovery(collection, doi: str) -> dict | None:
     return {"parent_doi": meta["parent_doi"], "edge_type": meta["edge_type"], "hop_depth": meta["hop_depth"]}
 
 
-def record_paper(collection, doi: str, abstract: str, discovered_via: dict | None) -> None:
+def record_paper(collection, doi: str, abstract: str, discovered_via: dict | None, full_text: bool = False) -> None:
     import time
 
     # created_epoch (not created_at) matches dump_collection.py's --since
@@ -94,12 +95,71 @@ def record_paper(collection, doi: str, abstract: str, discovered_via: dict | Non
     # (ISO-8601 strings aren't supported) -- same field name qa-knowledge
     # uses, so cross_machine_merge.py's incremental sync pattern works here
     # unmodified.
-    metadata = {"doi": doi, "created_epoch": time.time()}
+    metadata = {"doi": doi, "created_epoch": time.time(), "full_text": full_text}
     if discovered_via is not None:
         metadata["parent_doi"] = discovered_via["parent_doi"]
         metadata["edge_type"] = discovered_via["edge_type"]
         metadata["hop_depth"] = discovered_via["hop_depth"]
     collection.add(ids=[doi], documents=[abstract], metadatas=[metadata])
+
+
+def fetch_arxiv_pdf_text(arxiv_id: str) -> str | None:
+    """Fetch full PDF text from arXiv for a given arXiv ID.
+
+    Returns the extracted text on success, or None on 404/network failure.
+    Uses ingest_paper.extract_pdf() for parsing, so behavior is consistent
+    with paper-dive's main ingestion path.
+    """
+    url = f"https://arxiv.org/pdf/{arxiv_id}"
+    try:
+        resp = _get_with_retry(url, params={}, timeout=30, max_retries=3)
+    except Exception:
+        # network error, 404, etc. — gracefully degrade to abstract-only
+        return None
+
+    if resp.status_code == 404:
+        return None
+
+    try:
+        resp.raise_for_status()
+    except Exception:
+        return None
+
+    # Write PDF bytes to temp file, extract via ingest_paper
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(resp.content)
+            tmp_path = tmp.name
+
+        # Import ingest_paper to use its extract_pdf function
+        import sys
+        scripts_dir = Path(__file__).resolve().parent
+        sys.path.insert(0, str(scripts_dir))
+        import ingest_paper
+
+        text = ingest_paper.extract_pdf(Path(tmp_path))
+        return text
+    except Exception:
+        # PDF parse failed (scanned, corrupted, etc.) — gracefully degrade
+        return None
+    finally:
+        # clean up temp file
+        try:
+            Path(tmp_path).unlink()
+        except Exception:
+            pass
+
+
+def fetch_full_text(node: dict) -> str | None:
+    """Fetch full text for a high-relevance node if an arXiv ID is available.
+
+    Currently arXiv-only; returns None if no arXiv ID present or fetch fails.
+    A future legitimate open-access DOI resolver could be added here.
+    """
+    arxiv_id = node.get("arxiv_id")
+    if not arxiv_id:
+        return None
+    return fetch_arxiv_pdf_text(arxiv_id)
 
 
 _NEAR_FLOOR_MARGIN = 0.05
@@ -218,6 +278,7 @@ def _shape_and_score(papers: list[dict], seed_embeddings: dict, embed_fn, is_cit
         # traversal actually cover that population instead of silently
         # dropping it. See _s2_id() for how this gets re-prefixed on lookup.
         doi = external_ids.get("DOI") or external_ids.get("ArXiv")
+        arxiv_id = external_ids.get("ArXiv")  # preserve ArXiv ID separately for full-text fetch
         abstract = p.get("abstract") or p.get("title") or ""
         if not doi or not abstract:
             continue
@@ -226,7 +287,7 @@ def _shape_and_score(papers: list[dict], seed_embeddings: dict, embed_fn, is_cit
         candidate_embeddings = embed_fn(abstract)
         score = blended_score(seed_embeddings, candidate_embeddings)
         intent = "result" if is_citation and "result" in (p.get("intents") or []) else None
-        candidates.append({"doi": doi, "score": score, "intent": intent, "abstract": abstract})
+        candidates.append({"doi": doi, "arxiv_id": arxiv_id, "score": score, "intent": intent, "abstract": abstract})
     return candidates
 
 
@@ -276,6 +337,7 @@ def run_paper_graph(
     references_top_k: int = 10,
     citations_top_k: int = 5,
     relevance_floor: float = 0.65,
+    full_text_threshold: float = 0.85,
     diminishing_returns_window: int | None = 5,
     cost_ceiling: int | None = 100,
     on_checkpoint=None,
@@ -327,7 +389,17 @@ def run_paper_graph(
         if is_known(node["doi"], collection):
             continue
         abstract = node.get("abstract") or (seed_abstract if node["doi"] == seed_id else "")
-        record_paper(collection, doi=node["doi"], abstract=abstract, discovered_via=node["discovered_via"])
+
+        # Attempt full-text fetch for high-relevance nodes with arXiv IDs
+        full_text = False
+        document_text = abstract
+        if node["score"] >= full_text_threshold and node.get("arxiv_id"):
+            fetched_text = fetch_full_text(node)
+            if fetched_text:
+                document_text = fetched_text
+                full_text = True
+
+        record_paper(collection, doi=node["doi"], abstract=document_text, discovered_via=node["discovered_via"], full_text=full_text)
 
     return results
 
@@ -390,6 +462,7 @@ def traverse(
                     "doi": cand["doi"],
                     "score": cand["score"],
                     "abstract": cand.get("abstract", ""),
+                    "arxiv_id": cand.get("arxiv_id"),
                     "discovered_via": {
                         "parent_doi": doi,
                         "edge_type": _EDGE_TYPE_LABEL[edge_type],
@@ -435,6 +508,7 @@ def main() -> None:
     ap.add_argument("--references-top-k", type=int, default=10)
     ap.add_argument("--citations-top-k", type=int, default=5)
     ap.add_argument("--relevance-floor", type=float, default=0.65)
+    ap.add_argument("--full-text-threshold", type=float, default=0.85, help="Score threshold for full-text fetch from arXiv (default: 0.85)")
     ap.add_argument("--cost-ceiling", type=int, default=100)
     ap.add_argument("--diminishing-returns-window", type=int, default=5)
     args = ap.parse_args()
@@ -491,6 +565,7 @@ def main() -> None:
         references_top_k=args.references_top_k,
         citations_top_k=args.citations_top_k,
         relevance_floor=args.relevance_floor,
+        full_text_threshold=args.full_text_threshold,
         diminishing_returns_window=args.diminishing_returns_window,
         cost_ceiling=args.cost_ceiling,
         on_checkpoint=_confirm_checkpoint,

--- a/skills/paper-dive/scripts/tests/test_paper_graph.py
+++ b/skills/paper-dive/scripts/tests/test_paper_graph.py
@@ -29,6 +29,8 @@ from paper_graph import (
     _check_huggingface_reachable,
     _cosine_similarity,
     _shape_and_score,
+    fetch_arxiv_pdf_text,
+    fetch_full_text,
 )
 
 LIB = Path.home() / ".agents" / "lib"
@@ -824,6 +826,298 @@ def test_shape_and_score_selects_cross_camp_rebuttal_that_specter2_alone_would_c
     assert candidates[0]["doi"] == "10.1/rebuttal"
     assert candidates[0]["intent"] == "result"
     assert candidates[0]["score"] == pytest.approx(0.5)  # blended score, not 0.0
+
+
+# ── Full-text fetch for high-relevance nodes ─────────────────────────────────
+
+def test_shape_and_score_preserves_arxiv_id_separate_from_doi():
+    # AC1: arxiv_id must be distinct from doi for full-text fetch routing
+    seed_embeddings = {"specter2": [1.0, 0.0], "nomic": [1.0, 0.0]}
+    papers = [
+        # DOI + ArXiv both present
+        {
+            "title": "Has Both",
+            "abstract": "doi and arxiv",
+            "externalIds": {"DOI": "10.1/example", "ArXiv": "2503.03704"},
+        },
+        # ArXiv-only (no DOI)
+        {
+            "title": "ArXiv Only",
+            "abstract": "no doi preprint",
+            "externalIds": {"ArXiv": "2605.15338"},
+        },
+    ]
+
+    def fake_embed(text):
+        return {"specter2": [1.0, 0.0], "nomic": [1.0, 0.0]}
+
+    candidates = _shape_and_score(papers, seed_embeddings, embed_fn=fake_embed, is_citation=False)
+
+    assert len(candidates) == 2
+    both_present = candidates[0]
+    assert both_present["doi"] == "10.1/example"  # DOI picked as primary identifier
+    assert both_present["arxiv_id"] == "2503.03704"  # ArXiv preserved separately
+
+    arxiv_only = candidates[1]
+    assert arxiv_only["doi"] == "2605.15338"  # ArXiv used as fallback for doi
+    assert arxiv_only["arxiv_id"] == "2605.15338"  # ArXiv also available for fetch
+
+
+def test_fetch_arxiv_pdf_text_constructs_correct_url_and_extracts(monkeypatch):
+    # AC2: fetch_arxiv_pdf_text builds the right URL and uses ingest_paper.extract_pdf
+    captured_urls = []
+
+    class FakePdfResponse:
+        status_code = 200
+
+        def __init__(self):
+            self.content = b"PDF binary content"
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get_with_retry(url, params, timeout, max_retries=8):
+        captured_urls.append(url)
+        return FakePdfResponse()
+
+    monkeypatch.setattr("paper_graph._get_with_retry", fake_get_with_retry)
+
+    # Mock ingest_paper.extract_pdf to return test text
+    def fake_extract_pdf(path):
+        return "extracted paper text from arXiv"
+
+    # Patch the import inside fetch_arxiv_pdf_text
+    import sys
+    sys.modules["ingest_paper"] = type(sys)("ingest_paper")
+    sys.modules["ingest_paper"].extract_pdf = fake_extract_pdf
+
+    result = fetch_arxiv_pdf_text("2503.03704")
+
+    assert result == "extracted paper text from arXiv"
+    assert "https://arxiv.org/pdf/2503.03704" in captured_urls
+
+
+def test_fetch_arxiv_pdf_text_returns_none_on_404(monkeypatch):
+    # AC3: graceful degradation when PDF not found
+    class FakeResponse:
+        status_code = 404
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get_with_retry(url, params, timeout, max_retries=8):
+        return FakeResponse()
+
+    monkeypatch.setattr("paper_graph._get_with_retry", fake_get_with_retry)
+
+    result = fetch_arxiv_pdf_text("2503.03704")
+
+    assert result is None
+
+
+def test_fetch_arxiv_pdf_text_returns_none_on_network_error(monkeypatch):
+    # AC3: graceful degradation on network failure
+    def fake_get_with_retry(url, params, timeout, max_retries=8):
+        raise Exception("Network error")
+
+    monkeypatch.setattr("paper_graph._get_with_retry", fake_get_with_retry)
+
+    result = fetch_arxiv_pdf_text("2503.03704")
+
+    assert result is None
+
+
+def test_fetch_full_text_returns_none_when_no_arxiv_id():
+    # AC3: no Sci-Hub fallback — DOI-only papers stay abstract-only
+    node = {"doi": "10.1/example", "arxiv_id": None, "score": 0.9}
+
+    result = fetch_full_text(node)
+
+    assert result is None
+
+
+def test_record_paper_stamps_full_text_metadata(tmp_path):
+    # AC1: record_paper must store full_text flag in metadata
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.get_or_create_collection("paper-knowledge-test")
+
+    record_paper(
+        collection,
+        doi="10.1/with-full-text",
+        abstract="full text content here",
+        discovered_via=None,
+        full_text=True,
+    )
+
+    meta = collection.get(ids=["10.1/with-full-text"])["metadatas"][0]
+    assert meta["full_text"] is True
+
+    # Also test default (abstract-only)
+    record_paper(
+        collection,
+        doi="10.1/abstract-only",
+        abstract="abstract content",
+        discovered_via=None,
+        full_text=False,
+    )
+
+    meta2 = collection.get(ids=["10.1/abstract-only"])["metadatas"][0]
+    assert meta2["full_text"] is False
+
+
+def test_run_paper_graph_fetches_full_text_for_high_relevance_nodes_with_arxiv_id(
+    tmp_path, monkeypatch
+):
+    # AC1 & AC2: high-relevance node with arXiv ID → full text fetched and stored
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.get_or_create_collection("paper-knowledge")
+
+    graph = {
+        "seed": {
+            "references": [
+                {
+                    "doi": "ref-high-arxiv",
+                    "score": 0.88,
+                    "intent": None,
+                    "abstract": "abstract text",
+                    "arxiv_id": "2503.03704",
+                }
+            ],
+            "citations": [],
+        },
+    }
+
+    def fake_fetch(doi):
+        return graph[doi]
+
+    # Mock full-text fetch to return extracted text
+    def fake_fetch_full_text(node):
+        if node.get("arxiv_id") == "2503.03704":
+            return "This is the extracted full text from the PDF."
+        return None
+
+    monkeypatch.setattr("paper_graph.fetch_full_text", fake_fetch_full_text)
+
+    results = run_paper_graph(
+        seed_doi="seed",
+        seed_abstract="seed abstract",
+        collection=collection,
+        max_depth=1,
+        references_top_k=10,
+        citations_top_k=5,
+        relevance_floor=0.5,
+        full_text_threshold=0.85,  # ref-high-arxiv at 0.88 exceeds this
+        fetch_fn=fake_fetch,
+    )
+
+    # Verify the full text was stored
+    stored = collection.get(ids=["ref-high-arxiv"])
+    assert len(stored["ids"]) == 1
+    assert stored["documents"][0] == "This is the extracted full text from the PDF."
+    assert stored["metadatas"][0]["full_text"] is True
+
+
+def test_run_paper_graph_stores_abstract_for_high_relevance_node_without_arxiv_id(
+    tmp_path, monkeypatch
+):
+    # AC1 & AC3: high-relevance DOI-only node → abstract stored, full_text=False, fetch not called
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.get_or_create_collection("paper-knowledge")
+
+    graph = {
+        "seed": {
+            "references": [
+                {
+                    "doi": "ref-doi-only",
+                    "score": 0.88,
+                    "intent": None,
+                    "abstract": "abstract of doi-only paper",
+                    "arxiv_id": None,  # no ArXiv ID available
+                }
+            ],
+            "citations": [],
+        },
+    }
+
+    def fake_fetch(doi):
+        return graph[doi]
+
+    fetch_calls = []
+
+    def spy_fetch_full_text(node):
+        fetch_calls.append(node["doi"])
+        return None
+
+    monkeypatch.setattr("paper_graph.fetch_full_text", spy_fetch_full_text)
+
+    results = run_paper_graph(
+        seed_doi="seed",
+        seed_abstract="seed abstract",
+        collection=collection,
+        max_depth=1,
+        references_top_k=10,
+        citations_top_k=5,
+        relevance_floor=0.5,
+        full_text_threshold=0.85,
+        fetch_fn=fake_fetch,
+    )
+
+    # Verify the abstract was stored without attempting a fetch
+    stored = collection.get(ids=["ref-doi-only"])
+    assert stored["documents"][0] == "abstract of doi-only paper"
+    assert stored["metadatas"][0]["full_text"] is False
+    assert "ref-doi-only" not in fetch_calls  # fetch never called
+
+
+def test_run_paper_graph_never_fetches_for_below_threshold_nodes(tmp_path, monkeypatch):
+    # AC3: nodes below full_text_threshold must never trigger a fetch, even with arXiv ID
+    client = chromadb.PersistentClient(path=str(tmp_path))
+    collection = client.get_or_create_collection("paper-knowledge")
+
+    graph = {
+        "seed": {
+            "references": [
+                {
+                    "doi": "ref-below-threshold",
+                    "score": 0.75,  # below 0.85 threshold
+                    "intent": None,
+                    "abstract": "abstract of below-threshold paper",
+                    "arxiv_id": "2503.03704",  # has ArXiv ID but shouldn't be fetched
+                }
+            ],
+            "citations": [],
+        },
+    }
+
+    def fake_fetch(doi):
+        return graph[doi]
+
+    fetch_calls = []
+
+    def spy_fetch_full_text(node):
+        fetch_calls.append(node["doi"])
+        return "full text"
+
+    monkeypatch.setattr("paper_graph.fetch_full_text", spy_fetch_full_text)
+
+    results = run_paper_graph(
+        seed_doi="seed",
+        seed_abstract="seed abstract",
+        collection=collection,
+        max_depth=1,
+        references_top_k=10,
+        citations_top_k=5,
+        relevance_floor=0.5,
+        full_text_threshold=0.85,  # threshold is 0.85, node score is 0.75
+        fetch_fn=fake_fetch,
+    )
+
+    # Verify fetch was NEVER called for below-threshold node
+    assert "ref-below-threshold" not in fetch_calls
+    # Verify abstract stored with full_text=False
+    stored = collection.get(ids=["ref-below-threshold"])
+    assert stored["documents"][0] == "abstract of below-threshold paper"
+    assert stored["metadatas"][0]["full_text"] is False
 
 
 # ── AC2: skip already-known papers (embedding + fetch) ───────────────────────


### PR DESCRIPTION
Closes G-Eskayo/marvin#25

Autonomously implemented and verified by the MR pipeline.

## Metrics Comparison

**Subsystem**: ticket-25
**Verdict**: improved

| Metric | Baseline | Current | Delta | Direction |
|---|---|---|---|---|
| tests_passed | 431 | 440 | +9 | improved |
| tests_failed | 0 | 0 | +0 | unchanged |

## Test Results

**Suite**: /Users/gileskayo/.agents/venv/bin/python -m pytest -q
**Passed**: 440
**Failed**: 0
**Total**: 440

## Dev Environment Evidence

N/A — no UI