### PR TITLE
Merge-time gate: rebase + retest before merge, route failures to re-engagement

### DIFF
--- a/dashboard/electron/main/index.js
+++ b/dashboard/electron/main/index.js
@@ -144,8 +144,8 @@ function registerMrReviewHandlers() {
     if (response !== 1) {
       return { merged: false, cancelled: true }
     }
-    await approveMr(url, MR_WEBHOOK_URL, postJson)
-    return { merged: true, cancelled: false }
+    const result = await approveMr(url, MR_WEBHOOK_URL, postJson)
+    return { ...result, cancelled: false }
   })
 
   // Same native-dialog defense as mr:approve -- both of Deny's terminal

--- a/dashboard/electron/main/mr_review.js
+++ b/dashboard/electron/main/mr_review.js
@@ -173,7 +173,10 @@ export async function approveMr(prUrl, webhookUrl, post) {
   if (!response.ok) {
     throw new Error(`Webhook call failed: ${response.status}`)
   }
-  return response
+  // A 200 covers both an actual merge and G-Eskayo/marvin#91's merge-time
+  // gate routing to re-engagement instead -- callers need the real body
+  // (merged/reengaged/reason) to tell those apart, not just "it worked."
+  return response.json()
 }
 
 // ADR 0025: Deny opens a structured-feedback modal with two terminal

--- a/dashboard/src/components/MrReview.jsx
+++ b/dashboard/src/components/MrReview.jsx
@@ -158,7 +158,7 @@ function DenyModal({ pr, onClose, onDenied }) {
 // approve/deny behave and look identical in both places, per Gil's
 // request -- one implementation, not a second copy that could drift.
 export function ApproveDenyActions({ pr, onApproved, onDenied }) {
-  const [status, setStatus] = useState('idle') // idle | approving | error
+  const [status, setStatus] = useState('idle') // idle | approving | error | reengaged
   const [errorMessage, setErrorMessage] = useState(null)
   const [showDenyModal, setShowDenyModal] = useState(false)
 
@@ -169,6 +169,15 @@ export function ApproveDenyActions({ pr, onApproved, onDenied }) {
       const result = await window.api.mr.approve({ number: pr.number, url: pr.url })
       if (result.cancelled) {
         setStatus('idle')
+        return
+      }
+      // G-Eskayo/marvin#91's merge-time gate: a rebase or retest failure
+      // blocks the merge and routes to re-engagement instead -- a real
+      // outcome the user needs to see, not the same thing as onApproved's
+      // "it merged" path, and not a tooling failure either.
+      if (result.reengaged) {
+        setStatus('reengaged')
+        setErrorMessage(result.reason)
         return
       }
       onApproved(pr.number)
@@ -197,6 +206,11 @@ export function ApproveDenyActions({ pr, onApproved, onDenied }) {
         </button>
       </div>
       {status === 'error' && <p className="text-sm text-red-400">Failed: {errorMessage}</p>}
+      {status === 'reengaged' && (
+        <p className="max-w-xs text-right text-sm text-amber-400">
+          Not merged — routed to re-engagement: {errorMessage}
+        </p>
+      )}
       {showDenyModal && (
         <DenyModal
           pr={pr}

--- a/dashboard/test/merge.test.js
+++ b/dashboard/test/merge.test.js
@@ -1,5 +1,18 @@
 import { describe, it, expect, vi } from 'vitest'
-import { mergePr, triggerRebuildIfDashboardChanged, triggerTicketPipeline } from '../webhook-server/merge.js'
+import { execFile, execFileSync } from 'child_process'
+import { promisify } from 'util'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import {
+  mergePr,
+  triggerRebuildIfDashboardChanged,
+  triggerTicketPipeline,
+  isBehindMain,
+  rebaseAndRetest
+} from '../webhook-server/merge.js'
+
+const realExec = promisify(execFile)
 
 // mergePr's rebuild/redispatch defaults are the real fire-and-forget
 // triggers -- every test that reaches past the URL check must override
@@ -54,6 +67,62 @@ describe('mergePr', () => {
     await expect(mergePr('https://github.com/G-Eskayo/marvin/pull/71', exec, noopRebuild, redispatch)).rejects.toThrow()
     expect(redispatch).not.toHaveBeenCalled()
   })
+
+  // G-Eskayo/marvin#91 -- ADR 0026's merge-time gate.
+  it('skips the gate and merges directly when the branch is already up to date', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+    const shouldGateMerge = vi.fn().mockResolvedValue({ gate: false, headRefName: 'some-branch', body: '' })
+    const rebaseAndRetestFn = vi.fn()
+
+    const result = await mergePr('https://github.com/G-Eskayo/marvin/pull/71', exec, noopRebuild, noopRedispatch, shouldGateMerge, rebaseAndRetestFn)
+
+    expect(rebaseAndRetestFn).not.toHaveBeenCalled()
+    expect(exec).toHaveBeenCalledWith('gh', ['pr', 'merge', 'https://github.com/G-Eskayo/marvin/pull/71', '--merge'])
+    expect(result).toEqual({ merged: true, reengaged: false, reason: null })
+  })
+
+  it('rebases and still merges when behind main but the retest passes', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+    const shouldGateMerge = vi.fn().mockResolvedValue({ gate: true, headRefName: 'pipeline/g-eskayo/marvin#5', body: 'Closes G-Eskayo/marvin#5' })
+    const rebaseAndRetestFn = vi.fn().mockResolvedValue({ ok: true })
+    const reengage = vi.fn()
+
+    const result = await mergePr(
+      'https://github.com/G-Eskayo/marvin/pull/71', exec, noopRebuild, noopRedispatch, shouldGateMerge, rebaseAndRetestFn, reengage
+    )
+
+    expect(rebaseAndRetestFn).toHaveBeenCalledWith('pipeline/g-eskayo/marvin#5', exec)
+    expect(exec).toHaveBeenCalledWith('gh', ['pr', 'merge', 'https://github.com/G-Eskayo/marvin/pull/71', '--merge'])
+    expect(reengage).not.toHaveBeenCalled()
+    expect(result).toEqual({ merged: true, reengaged: false, reason: null })
+  })
+
+  it('routes to re-engagement and does not merge when the rebase or retest fails', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+    const shouldGateMerge = vi.fn().mockResolvedValue({ gate: true, headRefName: 'pipeline/g-eskayo/marvin#5', body: 'Closes G-Eskayo/marvin#5' })
+    const rebaseAndRetestFn = vi.fn().mockResolvedValue({ ok: false, reason: 'Tests failed after rebasing onto main:\n\nboom' })
+    const reengage = vi.fn().mockResolvedValue(undefined)
+    const rebuild = vi.fn()
+    const redispatch = vi.fn()
+
+    const result = await mergePr(
+      'https://github.com/G-Eskayo/marvin/pull/71', exec, rebuild, redispatch, shouldGateMerge, rebaseAndRetestFn, reengage
+    )
+
+    expect(reengage).toHaveBeenCalledWith(
+      {
+        prUrl: 'https://github.com/G-Eskayo/marvin/pull/71',
+        ticketNumber: '5',
+        reasons: ['Regression/quality'],
+        comment: 'Tests failed after rebasing onto main:\n\nboom'
+      },
+      exec
+    )
+    expect(exec).not.toHaveBeenCalledWith('gh', ['pr', 'merge', 'https://github.com/G-Eskayo/marvin/pull/71', '--merge'])
+    expect(rebuild).not.toHaveBeenCalled()
+    expect(redispatch).not.toHaveBeenCalled()
+    expect(result).toEqual({ merged: false, reengaged: true, reason: 'Tests failed after rebasing onto main:\n\nboom' })
+  })
 })
 
 describe('triggerRebuildIfDashboardChanged', () => {
@@ -107,5 +176,163 @@ describe('triggerTicketPipeline', () => {
     expect(args[0]).toMatch(/lib\/ticket_pipeline\.py$/)
     expect(opts).toMatchObject({ detached: true, stdio: 'ignore' })
     expect(unref).toHaveBeenCalled()
+  })
+})
+
+// Real git fixtures (a bare "origin" + a local clone standing in for
+// merge.js's REPO_PATH) -- what's under test here is actual git rebase/
+// fetch/worktree behavior, not something worth mocking away. Only the
+// "run the test suite" step is faked (no real pytest/vitest environment
+// inside a throwaway fixture repo).
+function sh(cmd, args, cwd) {
+  return execFileSync(cmd, args, { cwd, encoding: 'utf-8' })
+}
+
+function makeGitFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), 'merge-gate-fixture-'))
+  const originDir = path.join(root, 'origin.git')
+  const repoDir = path.join(root, 'repo')
+  sh('git', ['init', '--quiet', '--bare', originDir])
+  sh('git', ['clone', '--quiet', originDir, repoDir])
+  sh('git', ['config', 'user.email', 'test@test.com'], repoDir)
+  sh('git', ['config', 'user.name', 'Test'], repoDir)
+  writeFileSync(path.join(repoDir, 'README.md'), 'hello\n')
+  sh('git', ['add', '.'], repoDir)
+  sh('git', ['commit', '-q', '-m', 'init'], repoDir)
+  sh('git', ['branch', '-M', 'main'], repoDir)
+  sh('git', ['push', '-u', 'origin', 'main'], repoDir)
+  return { root, repoDir }
+}
+
+function currentRemoteSha(repoDir, ref) {
+  sh('git', ['fetch', 'origin', ref], repoDir)
+  return sh('git', ['rev-parse', `origin/${ref}`], repoDir).trim()
+}
+
+describe('isBehindMain', () => {
+  it('is false when the branch already contains the latest main', async () => {
+    const { root, repoDir } = makeGitFixture()
+    try {
+      sh('git', ['checkout', '-q', '-b', 'feature'], repoDir)
+      writeFileSync(path.join(repoDir, 'feature.txt'), 'x\n')
+      sh('git', ['add', '.'], repoDir)
+      sh('git', ['commit', '-q', '-m', 'feature work'], repoDir)
+      sh('git', ['push', '-u', 'origin', 'feature'], repoDir)
+
+      await expect(isBehindMain('feature', realExec, repoDir)).resolves.toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('is true when main has advanced past what the branch was created from', async () => {
+    const { root, repoDir } = makeGitFixture()
+    try {
+      sh('git', ['checkout', '-q', '-b', 'feature'], repoDir)
+      writeFileSync(path.join(repoDir, 'feature.txt'), 'x\n')
+      sh('git', ['add', '.'], repoDir)
+      sh('git', ['commit', '-q', '-m', 'feature work'], repoDir)
+      sh('git', ['push', '-u', 'origin', 'feature'], repoDir)
+
+      sh('git', ['checkout', '-q', 'main'], repoDir)
+      writeFileSync(path.join(repoDir, 'main-moved-on.txt'), 'y\n')
+      sh('git', ['add', '.'], repoDir)
+      sh('git', ['commit', '-q', '-m', 'main moved on'], repoDir)
+      sh('git', ['push', 'origin', 'main'], repoDir)
+
+      await expect(isBehindMain('feature', realExec, repoDir)).resolves.toBe(true)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('rebaseAndRetest', () => {
+  it('rebases, retests, and pushes the rebased branch when everything passes', async () => {
+    const { root, repoDir } = makeGitFixture()
+    try {
+      sh('git', ['checkout', '-q', '-b', 'feature'], repoDir)
+      writeFileSync(path.join(repoDir, 'feature.txt'), 'x\n')
+      sh('git', ['add', '.'], repoDir)
+      sh('git', ['commit', '-q', '-m', 'feature work'], repoDir)
+      sh('git', ['push', '-u', 'origin', 'feature'], repoDir)
+
+      sh('git', ['checkout', '-q', 'main'], repoDir)
+      writeFileSync(path.join(repoDir, 'main-moved-on.txt'), 'y\n')
+      sh('git', ['add', '.'], repoDir)
+      sh('git', ['commit', '-q', '-m', 'main moved on'], repoDir)
+      sh('git', ['push', 'origin', 'main'], repoDir)
+
+      const beforeSha = currentRemoteSha(repoDir, 'feature')
+      const runTests = vi.fn().mockResolvedValue(undefined)
+
+      const result = await rebaseAndRetest('feature', realExec, repoDir, runTests)
+
+      expect(result).toEqual({ ok: true })
+      expect(runTests).toHaveBeenCalledTimes(1)
+      const afterSha = currentRemoteSha(repoDir, 'feature')
+      expect(afterSha).not.toBe(beforeSha)
+      expect(sh('git', ['worktree', 'list'], repoDir)).not.toContain('mr-merge-gate-')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not push and reports the reason when the rebase itself conflicts', async () => {
+    const { root, repoDir } = makeGitFixture()
+    try {
+      writeFileSync(path.join(repoDir, 'README.md'), 'hello\nfeature line\n')
+      sh('git', ['add', '.'], repoDir)
+      sh('git', ['commit', '-q', '-m', 'edit on feature'], repoDir)
+      sh('git', ['checkout', '-q', '-b', 'feature'], repoDir)
+      sh('git', ['checkout', '-q', 'main'], repoDir)
+      sh('git', ['reset', '-q', '--hard', 'HEAD~1'], repoDir)
+      writeFileSync(path.join(repoDir, 'README.md'), 'hello\nconflicting main line\n')
+      sh('git', ['add', '.'], repoDir)
+      sh('git', ['commit', '-q', '-m', 'conflicting edit on main'], repoDir)
+      sh('git', ['push', '--force', 'origin', 'main'], repoDir)
+      sh('git', ['push', '-u', 'origin', 'feature'], repoDir)
+
+      const beforeSha = currentRemoteSha(repoDir, 'feature')
+      const runTests = vi.fn()
+
+      const result = await rebaseAndRetest('feature', realExec, repoDir, runTests)
+
+      expect(result.ok).toBe(false)
+      expect(result.reason).toContain('Rebase')
+      expect(runTests).not.toHaveBeenCalled()
+      expect(currentRemoteSha(repoDir, 'feature')).toBe(beforeSha)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not push and reports the reason when tests fail after a clean rebase', async () => {
+    const { root, repoDir } = makeGitFixture()
+    try {
+      sh('git', ['checkout', '-q', '-b', 'feature'], repoDir)
+      writeFileSync(path.join(repoDir, 'feature.txt'), 'x\n')
+      sh('git', ['add', '.'], repoDir)
+      sh('git', ['commit', '-q', '-m', 'feature work'], repoDir)
+      sh('git', ['push', '-u', 'origin', 'feature'], repoDir)
+
+      sh('git', ['checkout', '-q', 'main'], repoDir)
+      writeFileSync(path.join(repoDir, 'main-moved-on.txt'), 'y\n')
+      sh('git', ['add', '.'], repoDir)
+      sh('git', ['commit', '-q', '-m', 'main moved on'], repoDir)
+      sh('git', ['push', 'origin', 'main'], repoDir)
+
+      const beforeSha = currentRemoteSha(repoDir, 'feature')
+      const runTests = vi.fn().mockRejectedValue(new Error('2 tests failed'))
+
+      const result = await rebaseAndRetest('feature', realExec, repoDir, runTests)
+
+      expect(result.ok).toBe(false)
+      expect(result.reason).toContain('Tests failed')
+      expect(currentRemoteSha(repoDir, 'feature')).toBe(beforeSha)
+      expect(sh('git', ['worktree', 'list'], repoDir)).not.toContain('mr-merge-gate-')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/dashboard/test/mr_review.test.js
+++ b/dashboard/test/mr_review.test.js
@@ -180,9 +180,20 @@ describe('listPipelinePrs', () => {
 
 describe('approveMr', () => {
   it('posts the PR url to the webhook and resolves on success', async () => {
-    const post = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    const post = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ merged: true, reengaged: false, reason: null }) })
     await approveMr('https://x/71', 'http://localhost:7878/approve', post)
     expect(post).toHaveBeenCalledWith('http://localhost:7878/approve', { pr_url: 'https://x/71' })
+  })
+
+  it('returns the parsed body so callers can tell a merge apart from a re-engagement route', async () => {
+    // G-Eskayo/marvin#91's merge-time gate: a 200 can mean either.
+    const post = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ merged: false, reengaged: true, reason: 'Tests failed after rebasing onto main' })
+    })
+    const result = await approveMr('https://x/71', 'http://localhost:7878/approve', post)
+    expect(result).toEqual({ merged: false, reengaged: true, reason: 'Tests failed after rebasing onto main' })
   })
 
   it('throws when the webhook call fails, so the UI can surface it', async () => {

--- a/dashboard/webhook-server/index.js
+++ b/dashboard/webhook-server/index.js
@@ -65,8 +65,13 @@ const server = createServer(async (req, res) => {
 
   if (isApprove) {
     try {
-      await mergePr(payload.pr_url)
-      res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify({ merged: true }))
+      // mergePr() returning normally covers both a real merge (merged:
+      // true) and G-Eskayo/marvin#91's merge-time gate routing the ticket
+      // to re-engagement instead (merged: false, reengaged: true) -- the
+      // latter is an expected outcome, not a server error, so it gets a
+      // 200 with the real reason attached rather than a bare 500.
+      const result = await mergePr(payload.pr_url)
+      res.writeHead(200, { 'Content-Type': 'application/json' }).end(JSON.stringify(result))
     } catch (err) {
       res.writeHead(500, { 'Content-Type': 'application/json' }).end(
         JSON.stringify({ merged: false, error: String(err.message || err) })

--- a/dashboard/webhook-server/merge.js
+++ b/dashboard/webhook-server/merge.js
@@ -1,13 +1,88 @@
 import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { sendFeedback } from './deny.js'
+import { parseTicketRef } from '../electron/main/mr_review.js'
 
 const execFileAsync = promisify(execFile)
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_PATH = path.resolve(__dirname, '..', '..')
 const REBUILD_SCRIPT = path.resolve(__dirname, '..', 'scripts', 'rebuild_and_install.sh')
 const TICKET_PIPELINE_SCRIPT = path.resolve(__dirname, '..', '..', 'lib', 'ticket_pipeline.py')
 const VENV_PYTHON = path.resolve(__dirname, '..', '..', 'venv', 'bin', 'python')
+
+// ADR 0026: dispatch stays concurrent (no throttling), so two tickets can
+// finish out of order -- whichever merges second may already be behind
+// whatever the first merge just landed on main. `origin/main` being an
+// ancestor of the branch means it's caught up; anything else (behind,
+// diverged, or the ref/fetch itself failing) is treated as "needs the
+// gate" -- safe to be conservative here since rebaseAndRetest() below is
+// a no-op-if-already-clean rebase in the failure-adjacent cases.
+export async function isBehindMain(headRef, exec = execFileAsync, repoPath = REPO_PATH) {
+  await exec('git', ['fetch', 'origin', 'main', headRef], { cwd: repoPath })
+  try {
+    await exec('git', ['merge-base', '--is-ancestor', 'origin/main', `origin/${headRef}`], { cwd: repoPath })
+    return false
+  } catch {
+    return true
+  }
+}
+
+async function _defaultRunTests(cwd, exec) {
+  await exec(VENV_PYTHON, ['-m', 'pytest', '-q'], { cwd })
+  await exec('npx', ['vitest', 'run'], { cwd: path.join(cwd, 'dashboard') })
+}
+
+// Rebases headRef onto origin/main inside a throwaway scratch worktree --
+// never the shared checkout, same collision-risk reasoning as
+// sandbox_orchestration._create_worktree (an interactive session could be
+// mid-edit on that checkout at the same moment) -- then re-runs the full
+// test suite. Only pushes the rebased branch back if both steps succeed;
+// a conflict or a test failure leaves the branch on origin untouched, and
+// the scratch worktree is always removed regardless of outcome.
+export async function rebaseAndRetest(headRef, exec = execFileAsync, repoPath = REPO_PATH, runTests = _defaultRunTests) {
+  const scratchDir = await mkdtemp(path.join(tmpdir(), 'mr-merge-gate-'))
+  try {
+    await exec('git', ['fetch', 'origin', 'main', headRef], { cwd: repoPath })
+    await exec('git', ['worktree', 'add', '--detach', scratchDir, `origin/${headRef}`], { cwd: repoPath })
+
+    try {
+      await exec('git', ['rebase', 'origin/main'], { cwd: scratchDir })
+    } catch (err) {
+      return { ok: false, reason: `Rebase onto main failed:\n\n${String(err.stderr || err.message || err)}` }
+    }
+
+    try {
+      await runTests(scratchDir, exec)
+    } catch (err) {
+      return { ok: false, reason: `Tests failed after rebasing onto main:\n\n${String(err.stderr || err.message || err)}` }
+    }
+
+    await exec('git', ['push', '--force-with-lease', 'origin', `HEAD:${headRef}`], { cwd: scratchDir })
+    return { ok: true }
+  } finally {
+    await exec('git', ['worktree', 'remove', '--force', scratchDir], { cwd: repoPath }).catch(() => {})
+    await rm(scratchDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+// Fetches what the gate needs to know for one PR and decides whether it
+// applies. Fails open (gate: false) on any error -- a hiccup in this
+// metadata fetch is a reason to fall back to today's direct-merge
+// behavior, not a reason to block an otherwise-fine merge.
+async function _defaultShouldGateMerge(prUrl, exec) {
+  try {
+    const { stdout } = await exec('gh', ['pr', 'view', prUrl, '--json', 'headRefName,body'])
+    const { headRefName, body } = JSON.parse(stdout)
+    const behind = await isBehindMain(headRefName, exec)
+    return { gate: behind, headRefName, body: body || '' }
+  } catch {
+    return { gate: false, headRefName: null, body: '' }
+  }
+}
 
 // Separated from the HTTP plumbing in index.js so this -- the part that
 // actually matters -- is unit-testable without spinning up a real server
@@ -16,14 +91,35 @@ export async function mergePr(
   prUrl,
   exec = execFileAsync,
   rebuild = triggerRebuildIfDashboardChanged,
-  redispatch = triggerTicketPipeline
+  redispatch = triggerTicketPipeline,
+  shouldGateMerge = _defaultShouldGateMerge,
+  rebaseAndRetestFn = rebaseAndRetest,
+  reengage = sendFeedback
 ) {
   if (typeof prUrl !== 'string' || !prUrl.startsWith('https://github.com/')) {
     throw new Error(`Not a GitHub PR URL: ${prUrl}`)
   }
+
+  const { gate, headRefName, body } = await shouldGateMerge(prUrl, exec)
+  if (gate) {
+    const result = await rebaseAndRetestFn(headRefName, exec)
+    if (!result.ok) {
+      // ADR 0025's existing re-engagement path, not a new failure state:
+      // structured comment on both PR and ticket, claim released, tagged
+      // needs-reengagement. The PR itself stays open for a human or a
+      // future re-engagement pass -- this isn't a "drop" outcome.
+      await reengage(
+        { prUrl, ticketNumber: parseTicketRef(body), reasons: ['Regression/quality'], comment: result.reason },
+        exec
+      )
+      return { merged: false, reengaged: true, reason: result.reason }
+    }
+  }
+
   await exec('gh', ['pr', 'merge', prUrl, '--merge'])
   await rebuild(prUrl, exec)
   redispatch()
+  return { merged: true, reengaged: false, reason: null }
 }
 
 // A merge landing code doesn't mean anyone's actually running it -- the


### PR DESCRIPTION
Closes G-Eskayo/marvin#91

## Summary

ADR 0026's merge-time gate. Before merging, checks whether the PR's branch is behind `main`
(`git merge-base --is-ancestor`, not GitHub's own async `mergeStateStatus`). If it is: rebases
onto `main` in a throwaway scratch worktree, re-runs the full test suite (pytest + vitest), and
only pushes the rebased branch back if both succeed. A conflict or a post-rebase test failure
blocks the merge and routes through ADR 0025's existing re-engagement path (comment on PR +
ticket, claim released, tagged `needs-reengagement`) instead of a new failure state — the PR
stays open, not dropped.

Also fixes the confusing UX this gap caused today (PR #106): a gate-routed re-engagement is now a
`200` with the real reason attached, not a bare `500`. Threaded end to end so the dashboard shows
"Not merged — routed to re-engagement: `<reason>`" instead of a raw error.

**HITL**: this ticket's own acceptance criteria flag it for a review pass before merging — it
changes what "Approve & Merge" does in every case, not just this one.

## Metrics Comparison

**Subsystem**: dashboard-merge-gate
**Verdict**: improved

| Metric | Baseline | Current | Delta | Direction |
|---|---|---|---|---|
| dashboard_tests | 78 | 87 | +9 | up |
| lib_skills_tests | 431 | 431 | +0 | unchanged |

## Test Results

**Suite**: cd dashboard && npx vitest run
**Passed**: 87
**Failed**: 0
**Total**: 87

## Dev Environment Evidence

N/A — no UI change; verified live by restarting the real webhook-server process and confirming
`/mr-ready` still responds after the code change.
