### PR TITLE
Node-side machine identity + environment-aware webhook URLs (#112)

### DIFF
--- a/dashboard/electron/main/device_identity.js
+++ b/dashboard/electron/main/device_identity.js
@@ -1,0 +1,71 @@
+import { readFileSync, existsSync } from 'fs'
+import { homedir } from 'os'
+import { execFileSync } from 'child_process'
+import path from 'path'
+
+// Same registry cross_machine_merge.py/machine_profile.py maintain on the
+// Python side (see lib/machine_profile.py's NETWORK_PATH) -- read directly
+// here so the Electron main process doesn't need a Python subprocess just
+// to answer "which device am I".
+export const NETWORK_PATH = path.join(homedir(), '.claude', 'marvin-network.json')
+
+function defaultReadHardwareUuid() {
+  try {
+    const out = execFileSync('/usr/sbin/ioreg', ['-d2', '-c', 'IOPlatformExpertDevice'], { encoding: 'utf-8' })
+    const line = out.split('\n').find((l) => l.includes('IOPlatformUUID'))
+    return line ? line.split('"')[3] : ''
+  } catch {
+    return ''
+  }
+}
+
+function loadRegistry(networkPath) {
+  if (!existsSync(networkPath)) return {}
+  try {
+    return JSON.parse(readFileSync(networkPath, 'utf-8')).devices || {}
+  } catch {
+    return {}
+  }
+}
+
+// Mirrors machine_profile.py's registry_id(): matched by hardware UUID, not
+// hostname/label, so a rename or a second same-kind machine can't misidentify
+// this one.
+export function resolveDeviceId(readHardwareUuid = defaultReadHardwareUuid, networkPath = NETWORK_PATH) {
+  const myUuid = readHardwareUuid()
+  if (!myUuid) return null
+  const registry = loadRegistry(networkPath)
+  for (const [deviceId, info] of Object.entries(registry)) {
+    if (info.hardware_uuid === myUuid) return deviceId
+  }
+  return null
+}
+
+// ADR 0032's primary automation host -- the registry's "desktop"-kind
+// device, not a hardcoded id, so this still resolves if mac-mini-1 is ever
+// renamed or replaced.
+export function primaryHostTailscaleName(networkPath = NETWORK_PATH) {
+  const registry = loadRegistry(networkPath)
+  for (const info of Object.values(registry)) {
+    if (info.kind === 'desktop') return info.tailscale_hostname || null
+  }
+  return null
+}
+
+export function isPrimaryHost(readHardwareUuid = defaultReadHardwareUuid, networkPath = NETWORK_PATH) {
+  const registry = loadRegistry(networkPath)
+  const myId = resolveDeviceId(readHardwareUuid, networkPath)
+  return myId != null && registry[myId]?.kind === 'desktop'
+}
+
+// The default host for this machine's outbound calls to the MR-approval
+// webhook (ADR 0032): itself when it is the primary host, otherwise the
+// primary host's Tailscale hostname. Explicit MARVIN_* env vars still take
+// precedence over this -- see electron/main/index.js.
+export function resolveServiceDefaults(readHardwareUuid = defaultReadHardwareUuid, networkPath = NETWORK_PATH) {
+  if (isPrimaryHost(readHardwareUuid, networkPath)) {
+    return { host: 'localhost' }
+  }
+  const hostname = primaryHostTailscaleName(networkPath)
+  return { host: hostname || 'localhost' }
+}

--- a/dashboard/electron/main/index.js
+++ b/dashboard/electron/main/index.js
@@ -9,17 +9,22 @@ import { readSeenNumbers, markSeen, computeReviewStatus } from './mr_seen.js'
 import { readDispatchStatus } from './dispatch_status.js'
 import { createRefreshServer } from './refresh_server.js'
 import { adoptLoginShellPath } from './path.js'
+import { resolveServiceDefaults } from './device_identity.js'
 
 const execFileAsync = promisify(execFile)
 
 adoptLoginShellPath()
 
-// Overridable via env for pointing at a real n8n webhook once G-Eskayo/marvin#11's
-// "exact n8n node topology" downstream work exists; defaults to the reference
-// receiver in dashboard/webhook-server/ (see its README for the contract).
-const MR_WEBHOOK_URL = process.env.MARVIN_MR_WEBHOOK_URL || 'http://localhost:7878/approve'
+// ADR 0032: the webhook-server this app talks to lives on whichever
+// machine is the primary automation host, not always localhost -- see
+// device_identity.js. Overridable via env for pointing at a real n8n
+// webhook once G-Eskayo/marvin#11's "exact n8n node topology" downstream
+// work exists; defaults to the reference receiver in dashboard/webhook-server/
+// (see its README for the contract).
+const { host: defaultWebhookHost } = resolveServiceDefaults()
+const MR_WEBHOOK_URL = process.env.MARVIN_MR_WEBHOOK_URL || `http://${defaultWebhookHost}:7878/approve`
 // Same reference receiver, second endpoint -- ADR 0025's Deny action.
-const MR_DENY_WEBHOOK_URL = process.env.MARVIN_MR_DENY_WEBHOOK_URL || 'http://localhost:7878/deny'
+const MR_DENY_WEBHOOK_URL = process.env.MARVIN_MR_DENY_WEBHOOK_URL || `http://${defaultWebhookHost}:7878/deny`
 // Where the webhook-server process forwards its /mr-ready ping (see
 // dashboard/webhook-server/refresh_relay.js) so an already-open window
 // refreshes immediately instead of waiting on its own fallback poll.

--- a/dashboard/test/device_identity.test.js
+++ b/dashboard/test/device_identity.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { homedir } from 'os'
+import path from 'path'
+import {
+  resolveDeviceId,
+  primaryHostTailscaleName,
+  isPrimaryHost,
+  resolveServiceDefaults
+} from '../electron/main/device_identity.js'
+
+const registryFixture = {
+  'mac-mini-1': { hardware_uuid: 'MAC-MINI-UUID', kind: 'desktop', tailscale_hostname: 'gils-mac-mini' },
+  'macbook-pro-1': { hardware_uuid: 'MACBOOK-UUID', kind: 'laptop', tailscale_hostname: 'some-macbook' }
+}
+
+function withRegistry(devices, fn) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'device-identity-'))
+  const networkPath = path.join(dir, 'marvin-network.json')
+  writeFileSync(networkPath, JSON.stringify({ devices }))
+  try {
+    return fn(networkPath)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('resolveDeviceId', () => {
+  it('matches by hardware UUID, not label', () => {
+    withRegistry(registryFixture, (networkPath) => {
+      expect(resolveDeviceId(() => 'MACBOOK-UUID', networkPath)).toBe('macbook-pro-1')
+    })
+  })
+
+  it('returns null when this machine is not in the registry', () => {
+    withRegistry(registryFixture, (networkPath) => {
+      expect(resolveDeviceId(() => 'UNKNOWN-UUID', networkPath)).toBeNull()
+    })
+  })
+
+  it('returns null when the registry file does not exist', () => {
+    expect(resolveDeviceId(() => 'MAC-MINI-UUID', path.join(homedir(), 'nonexistent-marvin-network.json'))).toBeNull()
+  })
+})
+
+describe('primaryHostTailscaleName', () => {
+  it("resolves the registry's desktop-kind device hostname", () => {
+    withRegistry(registryFixture, (networkPath) => {
+      expect(primaryHostTailscaleName(networkPath)).toBe('gils-mac-mini')
+    })
+  })
+
+  it('returns null when no desktop-kind device is registered', () => {
+    withRegistry({ 'laptop-1': registryFixture['macbook-pro-1'] }, (networkPath) => {
+      expect(primaryHostTailscaleName(networkPath)).toBeNull()
+    })
+  })
+})
+
+describe('isPrimaryHost', () => {
+  it('is true when this machine is the desktop-kind device', () => {
+    withRegistry(registryFixture, (networkPath) => {
+      expect(isPrimaryHost(() => 'MAC-MINI-UUID', networkPath)).toBe(true)
+    })
+  })
+
+  it('is false for any other registered device', () => {
+    withRegistry(registryFixture, (networkPath) => {
+      expect(isPrimaryHost(() => 'MACBOOK-UUID', networkPath)).toBe(false)
+    })
+  })
+
+  it('is false when this machine is not registered at all', () => {
+    withRegistry(registryFixture, (networkPath) => {
+      expect(isPrimaryHost(() => 'UNKNOWN-UUID', networkPath)).toBe(false)
+    })
+  })
+})
+
+describe('resolveServiceDefaults', () => {
+  it('defaults to localhost on the primary host', () => {
+    withRegistry(registryFixture, (networkPath) => {
+      expect(resolveServiceDefaults(() => 'MAC-MINI-UUID', networkPath)).toEqual({ host: 'localhost' })
+    })
+  })
+
+  it("defaults to the primary host's tailscale hostname on any other registered device", () => {
+    withRegistry(registryFixture, (networkPath) => {
+      expect(resolveServiceDefaults(() => 'MACBOOK-UUID', networkPath)).toEqual({ host: 'gils-mac-mini' })
+    })
+  })
+
+  it('falls back to localhost when the primary host itself is unresolvable', () => {
+    withRegistry({ 'macbook-pro-1': registryFixture['macbook-pro-1'] }, (networkPath) => {
+      expect(resolveServiceDefaults(() => 'MACBOOK-UUID', networkPath)).toEqual({ host: 'localhost' })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- New `device_identity.js` resolves "which registered device am I" by hardware UUID against `~/.claude/marvin-network.json` — same match rule as `machine_profile.py`'s `registry_id()`, no Python subprocess needed.
- `electron/main/index.js`'s `MR_WEBHOOK_URL`/`MR_DENY_WEBHOOK_URL` now default to ADR 0032's primary host (the registry's `desktop`-kind device) instead of always `localhost`; `MARVIN_MR_WEBHOOK_URL`/`MARVIN_MR_DENY_WEBHOOK_URL` env overrides still win.
- Verified live on macbook-pro: `resolveServiceDefaults()` correctly returns `{ host: 'gils-mac-mini' }`.

## Deviation from stated acceptance criteria

#112 also names `MARVIN_DASHBOARD_REFRESH_URL` and `MARVIN_DASHBOARD_REFRESH_PORT` as targets. Left both untouched:

- `MARVIN_DASHBOARD_REFRESH_PORT` is `electron/main`'s own local bind port for its refresh listener — a port number, not a target host, and not device-dependent.
- `MARVIN_DASHBOARD_REFRESH_URL` is consumed by the separate `webhook-server` process (not the Electron main process) to ping wherever the Electron GUI happens to be running. Per ADR 0032, the GUI itself isn't relocated — it "stays wherever Gil is sitting" — so "point at mac-mini" isn't the right default for this one; the existing `localhost` default (each machine's webhook-server pinging its own possibly-running local GUI) is already the closest fit until GUI-location tracking exists.

Flagging this rather than forcing in a change that doesn't match how those two vars are actually used.

## Test plan

- [x] `npx vitest run test/device_identity.test.js` — 11/11 pass (device match, primary-host resolution, service-default fallback, unregistered-machine edge cases)
- [x] Full `npx vitest run` — 107/107 pass, no regressions
- [x] Manual: ran `resolveServiceDefaults()` live on this machine (macbook-pro), confirmed `{ host: 'gils-mac-mini' }`

## Note for a future ticket

Running `vitest`/`electron-vite` inside a `~/.agents-pipeline-worktrees/pipeline-g-eskayo-marvin#<n>` worktree fails outright — the `#` in the worktree directory name breaks Vite's URL-based module resolution (`Cannot find module '/test/...'`). No prior ticket has hit this because none previously touched `dashboard/`. Verification above was run from the worktree via direct `node -e` import plus the full suite pre-verified in the main checkout before committing; the worktree's own `vitest run` cannot currently execute for any dashboard-touching ticket. Worth its own ticket to rename the worktree scheme (e.g. `-issue-112` instead of `#112`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYuNxeDFNS31Zyar8uwL4b
